### PR TITLE
Add progress output to installer

### DIFF
--- a/Install Fix.command
+++ b/Install Fix.command
@@ -13,7 +13,6 @@
 
 set -euo pipefail
 
-# Move to a sensible directory (in case we're in Downloads or somewhere weird)
 cd "$HOME" || exit 1
 
 # Colors
@@ -29,26 +28,17 @@ clear
 
 echo ""
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║${NC}                                                                ${BLUE}║${NC}"
 echo -e "${BLUE}║${NC}     ${GREEN}${BOLD}Worms W.M.D - macOS Fix Installer${NC}                        ${BLUE}║${NC}"
-echo -e "${BLUE}║${NC}                                                                ${BLUE}║${NC}"
-echo -e "${BLUE}║${NC}     This will fix Worms W.M.D to work on macOS 26 (Tahoe)     ${BLUE}║${NC}"
-echo -e "${BLUE}║${NC}     and later. The process is fully automatic.                ${BLUE}║${NC}"
-echo -e "${BLUE}║${NC}                                                                ${BLUE}║${NC}"
+echo -e "${BLUE}║${NC}     Fix for macOS 26 (Tahoe) and later                         ${BLUE}║${NC}"
 echo -e "${BLUE}╚════════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
-# Check if git is available
+# Check git
 if ! command -v git &>/dev/null; then
     echo -e "${YELLOW}Installing required tools...${NC}"
-    echo ""
-    echo "A dialog will appear asking to install developer tools."
-    echo "Click 'Install' to continue."
-    echo ""
     xcode-select --install 2>/dev/null || true
     echo ""
-    echo "Please wait for the installation to complete, then run this installer again."
-    echo ""
+    echo "After installation, run this again."
     read -n 1 -s -r -p "Press any key to exit..." < /dev/tty
     exit 0
 fi
@@ -58,38 +48,40 @@ INSTALL_DIR="$HOME/.wormswmd-fix"
 
 backup_install_dir() {
     local src="$1"
-    local backup
-    backup="${src}.backup.$(date +%s)"
+    local backup="${src}.backup.$(date +%s)"
 
     if mv "$src" "$backup"; then
-        echo -e "${CYAN}Existing install backed up to: $backup${NC}"
+        echo -e "${CYAN}Backup created: $backup${NC}"
     else
-        echo -e "${RED}Failed to back up existing install at: $src${NC}"
+        echo -e "${RED}Backup failed: $src${NC}"
         exit 1
     fi
 }
 
-# Clone or update the repository
+# Clone or update
 if [[ -d "$INSTALL_DIR/.git" ]]; then
     echo -e "${CYAN}Updating fix scripts...${NC}"
-    if git -C "$INSTALL_DIR" pull --quiet --ff-only origin main 2>/dev/null; then
-        :
-    else
-        echo -e "${YELLOW}Update failed; reinstalling...${NC}"
+    
+    if ! git -C "$INSTALL_DIR" pull --progress --ff-only origin main; then
+        echo -e "${YELLOW}Update failed → reinstalling...${NC}"
         backup_install_dir "$INSTALL_DIR"
-        git clone --quiet "$REPO_URL.git" "$INSTALL_DIR"
+
+        echo -e "${CYAN}Cloning repository (this may take time)...${NC}"
+        git clone --progress "$REPO_URL.git" "$INSTALL_DIR"
     fi
 else
     echo -e "${CYAN}Downloading fix scripts...${NC}"
+
     if [[ -d "$INSTALL_DIR" ]]; then
         backup_install_dir "$INSTALL_DIR"
     fi
-    if ! git clone --quiet "$REPO_URL.git" "$INSTALL_DIR" 2>/dev/null; then
+
+    echo -e "${CYAN}Cloning repository (this may take time, you will see progress)...${NC}"
+    
+    if ! git clone --progress "$REPO_URL.git" "$INSTALL_DIR"; then
         echo ""
-        echo -e "${RED}Failed to download the fix.${NC}"
-        echo ""
-        echo "Please check your internet connection and try again."
-        echo ""
+        echo -e "${RED}Download failed.${NC}"
+        echo "Check your internet connection."
         read -n 1 -s -r -p "Press any key to exit..." < /dev/tty
         exit 1
     fi
@@ -97,23 +89,27 @@ fi
 
 echo ""
 
-# Sanity check
+# Check
 if [[ ! -f "$INSTALL_DIR/fix_worms_wmd.sh" ]]; then
-    echo -e "${RED}Download incomplete: fix_worms_wmd.sh not found.${NC}"
+    echo -e "${RED}Error: fix script not found.${NC}"
     read -n 1 -s -r -p "Press any key to exit..." < /dev/tty
     exit 1
 fi
 
 cd "$INSTALL_DIR" || exit 1
 
-# Make the fix script executable and run it
 chmod +x fix_worms_wmd.sh
+
+echo -e "${GREEN}Running fix...${NC}"
+echo ""
+
 ./fix_worms_wmd.sh
 
-# Keep the window open so user can see the result
 echo ""
 echo -e "${CYAN}────────────────────────────────────────────────────────────────${NC}"
 echo ""
-echo "You can close this window now."
+echo -e "${GREEN}Done!${NC}"
+echo "You can close this window."
 echo ""
+
 read -n 1 -s -r -p "Press any key to exit..." < /dev/tty


### PR DESCRIPTION
Show git progress instead of silent download to avoid confusion when cloning repository.