### PR TITLE
[codex] Fix issue 12 runtime hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,6 +90,6 @@ body:
     id: support_bundle
     attributes:
       label: Support bundle or logs
-      description: If this is not documentation-only, attach a sanitized support bundle from launcher option 5 or paste reviewed, redacted output. The bundle includes macOS and Rosetta details. Do not upload raw `.log` or `.trace` files.
+      description: If this is not documentation-only, attach a sanitized support bundle from launcher option 5 or paste reviewed, redacted output. The bundle includes macOS and Rosetta details, installer history, runtime invariant status, Qt package checks, and backup integrity status. Do not upload raw `.log` or `.trace` files.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/install_failure.yml
+++ b/.github/ISSUE_TEMPLATE/install_failure.yml
@@ -75,7 +75,7 @@ body:
     id: support_bundle
     attributes:
       label: Support bundle
-      description: Attach the sanitized `wormswmd-support-*.tar.gz` file from your Desktop. It includes macOS and Rosetta details. If you cannot attach it, explain why.
+      description: Attach the sanitized `wormswmd-support-*.tar.gz` file from your Desktop. It includes macOS and Rosetta details, installer history, runtime invariant status, Qt package checks, and backup integrity status. If you cannot attach it, explain why.
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Test issue 11 game detection
         run: ./tools/test_issue_11_game_detection.sh
 
+      - name: Test issue 12 AGL install failure
+        run: ./tools/test_issue_12_agl_install_failure.sh
+
+      - name: Test installer rollback regression
+        run: ./tools/test_installer_rollback_regression.sh
+
       - name: Test support bundle sanitization
         run: ./tools/test_support_bundle_sanitization.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,20 @@ jobs:
       - name: Check Qt package
         run: ./scripts/download_qt_frameworks.sh --check
 
+      - name: Compute release names
+        id: release_names
+        shell: bash
+        run: |
+          ref_name="${GITHUB_REF_NAME:-manual}"
+          safe_ref="${ref_name//[^A-Za-z0-9._-]/-}"
+          if [[ -z "$safe_ref" || "$safe_ref" == "." || "$safe_ref" == ".." ]]; then
+            safe_ref="manual"
+          fi
+          echo "version=$safe_ref" >> "$GITHUB_OUTPUT"
+          echo "artifact=WormsWMD-macOS-Fix-$safe_ref" >> "$GITHUB_OUTPUT"
+
       - name: Build release zip
-        run: ./tools/build_release_bundle.sh --version "${GITHUB_REF_NAME:-manual}"
+        run: ./tools/build_release_bundle.sh --version "${{ steps.release_names.outputs.version }}"
 
       - name: Attest release assets
         # actions/attest v4.1.0
@@ -52,7 +64,7 @@ jobs:
         # actions/upload-artifact v7.0.1
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: WormsWMD-macOS-Fix-${{ github.ref_name || 'manual' }}
+          name: ${{ steps.release_names.outputs.artifact }}
           path: |
             build/release/WormsWMD-macOS-Fix-*.zip
             build/release/WormsWMD-macOS-Fix-*.zip.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ change.
 ./tools/test_dependency_parsing.sh
 ./tools/test_issue_10_regression.sh
 ./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
 ./tools/test_support_bundle_sanitization.sh
 ./tools/test_backup_saves_regression.sh
 ./tools/test_launcher_friction.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Notable changes are listed here. This project follows Keep a Changelog and Seman
   enforced as installer invariants. If the release artifact, cache, build
   output, or selected Qt source is incomplete, the installer now fails clearly
   instead of continuing toward a partial black-screen state.
+- Fixed support-bundle troubleshooting gaps by adding sanitized installer
+  history, runtime invariant status, backup integrity status, and required Qt
+  archive content checks.
+- Fixed default installer log naming so simultaneous runs do not reuse one
+  timestamp-only log file.
 - Fixed AGL stub building on macOS 27 Apple Silicon Command Line Tools by using
   native `clang -arch x86_64` cross-compilation instead of launching `clang`
   under Rosetta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Notable changes are listed here. This project follows Keep a Changelog and Seman
   failures inside installer functions.
 - Fixed Steam update watcher reapply paths so custom `GAME_APP` locations are
   forwarded and persisted in the LaunchAgent.
+- Fixed manually dispatched release-bundle workflow artifact names for branch
+  refs containing `/`.
 - Fixed save restore semantics so restored backup roots replace stale local save
   files instead of merging over them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ Notable changes are listed here. This project follows Keep a Changelog and Seman
 ## Unreleased
 
 ### Fixed
-- Fixed issue #12 hardening so missing AGL binaries, non-x86_64 AGL stubs,
-  missing required Qt frameworks/plugins, or missing bundled Qt dependencies
-  fail clearly instead of continuing toward a partial black-screen state.
+- Fixed issue #12 hardening so required runtime assets supplied by the fixer are
+  enforced as installer invariants. If the release artifact, cache, build
+  output, or selected Qt source is incomplete, the installer now fails clearly
+  instead of continuing toward a partial black-screen state.
 - Fixed AGL stub building on macOS 27 Apple Silicon Command Line Tools by using
   native `clang -arch x86_64` cross-compilation instead of launching `clang`
   under Rosetta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ Notable changes are listed here. This project follows Keep a Changelog and Seman
 
 ## Unreleased
 
-No user-facing changes yet.
+### Fixed
+- Fixed issue #12 hardening so missing AGL binaries, non-x86_64 AGL stubs,
+  missing required Qt frameworks/plugins, or missing bundled Qt dependencies
+  fail clearly instead of continuing toward a partial black-screen state.
+- Fixed AGL stub building on macOS 27 Apple Silicon Command Line Tools by using
+  native `clang -arch x86_64` cross-compilation instead of launching `clang`
+  under Rosetta.
+- Fixed repeated AGL framework installs so stale nested framework symlinks are
+  repaired before backup manifest validation and are not recreated during AGL
+  replacement.
+- Fixed installer rollback on Bash 3.2 by enabling `ERR` trap inheritance for
+  failures inside installer functions.
+- Fixed Steam update watcher reapply paths so custom `GAME_APP` locations are
+  forwarded and persisted in the LaunchAgent.
+- Fixed save restore semantics so restored backup roots replace stale local save
+  files instead of merging over them.
 
 ## Mainline maintenance after 1.7.2 (2026-06-22)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ Include this information:
 - Error output or logs
 - Log file path from `~/Library/Logs/WormsWMD-Fix/`
 - Support bundle from `Worms W.M.D Fix.command` option 5, when available. It
-  includes macOS and Rosetta details needed for macOS 27 reports.
+  includes macOS and Rosetta details, sanitized installer history, runtime
+  invariant status, Qt package checks, and backup integrity status.
 - Steps to reproduce
 - Whether you tried `--restore` and re-applied the fix
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If macOS blocks the launcher, right-click `Worms W.M.D Fix.command`, choose
 | macOS 27 | Golden Gate is validated with Rosetta installed on Apple Silicon. |
 | Rosetta guidance | The launcher and preflight checks explain that Worms is an older Intel Mac game and show the install command when Rosetta is missing. |
 | Launch readiness | Launcher option `3` now checks both system readiness and the fixed game bundle before launch. |
-| Support bundles | Diagnostics now include macOS version, Rosetta package version, x86_64 execution status, `oahd` status, and macOS 27 game-support status when available. |
+| Support bundles | Diagnostics include macOS and Rosetta status, installer history, runtime invariant status, Qt package checks, and backup integrity status when available. |
 | macOS 26 | Tahoe behavior remains covered by regression tests and still uses the same AGL fix path. |
 | Release hygiene | The validation harness now fails if accidental workstation-local paths are added to tracked text files. |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -233,7 +233,7 @@ Last audit: 2026-06-22
 | Symlink attacks | Pass | Main installer uses a per-run `mktemp` build directory, cleanup traps, bundle containment checks, and archive link rejection |
 | Race conditions | Pass | Atomic operations where possible |
 | Secret exposure | Pass | No credentials in fix code; game config secrets documented in report |
-| Support bundle privacy | Pass | Sanitized bundles include OS and Rosetta context without raw logs, saves, game binaries, or private config contents |
+| Support bundle privacy | Pass | Sanitized bundles include OS, Rosetta, installer-history, runtime-invariant, Qt-package, and backup-integrity context without raw logs, saves, game binaries, or private config contents |
 | Dependency security | Pass | Checksums, metadata, manifests, and x86_64 slice checks for pre-built Qt |
 | Code signing | Pass | Ad-hoc signature applied, quarantine cleared |
 | Input validation | Pass | Environment variables and user input validated |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,7 +30,8 @@ still behaves incorrectly.
 Do not paste Steam account tokens, private config files, save archives, or game
 binaries into a public issue. The support bundle is designed to include
 sanitized diagnostics, macOS version, Rosetta package version when available,
-x86_64 execution status, Qt package status, and backup manifests only. Avoid
+x86_64 execution status, sanitized installer history, runtime invariant status,
+Qt package status, backup integrity status, and backup manifests only. Avoid
 uploading raw `.log` or `.trace` files; use the support bundle unless a
 maintainer specifically asks for a reviewed, redacted excerpt.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,53 +70,28 @@ To see what the fix does without applying it, run:
 
 ## Install manually
 
-Run these scripts in order:
+Use the canonical fixer even when installing manually. It creates a backup,
+verifies the runtime, and rolls back automatically if a mutating step fails.
+The helper scripts under `scripts/` are internal building blocks and do not
+provide the same recovery path when run one by one.
 
 ```bash
 git clone --branch v1.7.2 --depth 1 https://github.com/cboyd0319/WormsWMD-macOS-Fix.git
 cd WormsWMD-macOS-Fix
 
-# Use an isolated build directory for the AGL stub.
-export BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agl_stub_build.XXXXXX")"
-trap 'rm -rf "$BUILD_DIR"' EXIT
+# Optional: set this only when the game is outside the usual Steam/GOG paths.
+export GAME_APP="/path/to/Worms W.M.D.app"
 
-# Step 1: Build the AGL stub library
-./scripts/01_build_agl_stub.sh
-
-# Prepare the pre-built Qt framework package.
-QT_OUTPUT="$(./scripts/download_qt_frameworks.sh)"
-QT_EXTRACT_DIR="$(printf '%s\n' "$QT_OUTPUT" | tail -1)"
-if [[ ! -d "$QT_EXTRACT_DIR/Frameworks" ]]; then
-  echo "Pre-built Qt package is unavailable. Use the Homebrew fallback below."
-  exit 1
-fi
-export QT_SOURCE=prebuild
-export QT_PREFIX="$QT_EXTRACT_DIR"
-
-# Step 2: Replace Qt frameworks
-./scripts/02_replace_qt_frameworks.sh
-
-# Step 3: Copy required dependencies
-./scripts/03_copy_dependencies.sh
-
-# Step 4: Fix all library path references
-./scripts/04_fix_library_paths.sh
-
-# Step 5: Fix Info.plist metadata
-./scripts/06_fix_info_plist.sh
-
-# Step 6: Secure config URLs
-./scripts/07_fix_config_urls.sh
-
-# Step 7: Verify the installation
-./scripts/05_verify_installation.sh
+./fix_worms_wmd.sh --dry-run
+./fix_worms_wmd.sh
 ```
 
-If the pre-built Qt package is unavailable, install Intel Homebrew Qt and set:
+If the pre-built Qt package is unavailable, install Intel Homebrew Qt and let
+the fixer detect it:
 
 ```bash
-export QT_SOURCE=homebrew
-export QT_PREFIX=/usr/local/opt/qt@5
+arch -x86_64 /usr/local/bin/brew install qt@5
+./fix_worms_wmd.sh
 ```
 
 ## Set a custom game location

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,11 @@ current when adding, moving, renaming, or deleting Markdown files.
 - [Issue 11 game detection plan](exec-plans/2026-06-22-issue-11-game-detection.md)
   - completed fix for Bash 3.2 strict-mode game discovery and GOG install
     detection.
+- [Issue 12 AGL stub install failure plan](exec-plans/2026-06-29-issue-12-agl-stub-install.md)
+  - completed fix for missing AGL and required Qt runtime partial installs.
+- [Full repository deep audit plan](exec-plans/2026-06-29-full-repo-deep-audit.md)
+  - active repo-wide audit of installer, launcher, diagnostics, backup,
+    release, CI, and documentation behavior.
 - [macOS 27 Golden Gate compatibility plan](exec-plans/2026-06-22-macos-27-golden-gate.md)
   - completed full-repo compatibility and release-gate pass for macOS 27.
 - [Cheat sheet supply-chain hardening plan](exec-plans/2026-06-18-cheatsheet-supply-chain-hardening.md)

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -107,7 +107,8 @@ Diagnostics output and support bundles are sanitized for issue reporting. The
 collector redacts home-account paths, external volume paths, temporary paths,
 email addresses, and common secret-like key/value strings. Support bundles
 contain diagnostics, macOS version, Rosetta package version when available,
-x86_64 execution status, pre-built Qt package verification details, and
+x86_64 execution status, sanitized installer history, runtime invariant status,
+pre-built Qt package verification details, backup integrity status, and
 available backup manifests; they do not include raw logs, crash logs, save
 files, game binaries, or private config file contents. The support-bundle
 archive also normalizes tar owner and group metadata so it does not expose the

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -36,8 +36,10 @@ Back up and restore your save games, settings, and replays:
 ```
 
 New save backups include a `MANIFEST.tsv` file. Restore validates archive
-layout before extraction, verifies the manifest when present, and warns when
-restoring older legacy backups that predate manifests.
+layout before extraction, verifies the manifest when present, copies backup
+contents into a temporary tree, replaces the backed-up save roots, and verifies
+that stale files absent from the backup did not survive. Older legacy backups
+that predate manifests restore with an explicit warning.
 
 ## Steam update watcher
 
@@ -52,7 +54,8 @@ Steam's **Verify integrity of game files** overwrites the fix. Use the watcher t
 
 The watcher uses the same common game discovery as the installer when
 `GAME_APP` is not set, so it can check common Steam, GOG, Applications, and
-Games-folder installs.
+Games-folder installs. When installed as a LaunchAgent, it persists the selected
+`GAME_APP` so automatic reapply targets the same bundle.
 
 ## Steam launch options integration
 
@@ -138,6 +141,8 @@ or docs-topology changes:
 ./tools/test_dependency_parsing.sh
 ./tools/test_issue_10_regression.sh
 ./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
 ./tools/test_support_bundle_sanitization.sh
 ./tools/test_backup_saves_regression.sh
 ./tools/test_launcher_friction.sh

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -213,7 +213,8 @@ To gather system information for a bug report:
 
 Use `--bundle` when opening a community issue. It creates a sanitized support
 archive on your Desktop with diagnostics, macOS version, Rosetta package
-version when available, x86_64 execution status, Qt package verification
-details, and backup manifests when available. Do not upload raw `.log` or
+version when available, x86_64 execution status, sanitized installer history,
+runtime invariant status, Qt package verification details, backup integrity
+status, and backup manifests when available. Do not upload raw `.log` or
 `.trace` files unless you have reviewed and redacted account names, private
 paths, tokens, and private config values.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -92,10 +92,18 @@ The game window may appear very small after applying the fix. This happens becau
    ```bash
    ./fix_worms_wmd.sh --verify
    ```
-3. Check crash logs:
+3. If verification says `AGL stub not found` or diagnostics say
+   `AGL stub NOT installed`, run the launcher option `1` again. If it still
+   fails, choose launcher option `5` and attach the support bundle to a GitHub
+   issue.
+4. If backup creation reports a symlink or manifest error for
+   `AGL.framework`, update to the latest fixer and run option `1` again. The
+   current fixer repairs stale AGL framework links from older repeated installs
+   before validating the backup.
+5. Check crash logs:
    - Open **Console.app**
    - Look for entries related to "Worms" in **Crash Reports**
-4. Try a clean install:
+6. Try a clean install:
    - Restore original files: `./fix_worms_wmd.sh --restore`
    - Uninstall the game in Steam or GOG Galaxy
    - Reinstall the game

--- a/docs/design/runtime-contracts.md
+++ b/docs/design/runtime-contracts.md
@@ -74,11 +74,18 @@ must verify it before copying files back and must verify the restored files
 afterward. Backups without a manifest are legacy backups and may be restored
 only with an explicit warning.
 
+Backup creation may repair the fixer's own stale AGL framework symlink layout
+inside the backup copy before manifest validation. This self-heals repeated
+installs from older fixer versions without mutating save data or trusting
+symlinks that escape the backup root.
+
 Save-game backup behavior belongs to `tools/backup_saves.sh` and must remain
 separate from game-bundle restore behavior. Save-game archives must validate
 their tar layout and entry metadata before extraction, reject symlinks,
-hardlinks, and special files, verify `MANIFEST.tsv` when present, and warn when
-restoring older archives that do not include a manifest.
+hardlinks, and special files, verify `MANIFEST.tsv` when present, restore
+backed-up save roots from a temporary copy before replacing the target, detect
+stale files that were absent from the backup, and warn when restoring older
+archives that do not include a manifest.
 
 ## Qt Distribution Contract
 
@@ -97,6 +104,13 @@ When replacing the Qt archive:
   slices.
 - Run the packaging or install verification relevant to the change.
 - Update user docs if the version, source, or fallback behavior changes.
+
+Installer and verifier success requires the runtime pieces the game needs to
+launch: an AGL stub binary with an x86_64 slice, QtCore, QtGui, QtWidgets,
+QtOpenGL, QtPrintSupport, QtDBus, QtSvg, `PlugIns/platforms/libqcocoa.dylib`,
+`PlugIns/imageformats/libqsvg.dylib`, and the required bundled Qt dependency
+dylibs. Missing required runtime inputs must fail before destructive replacement
+where possible, and post-backup failures must trigger rollback.
 
 When multiple local Qt packages are present, scripts should choose the highest
 verified supported Qt 5.15.x version rather than the newest file by modification
@@ -171,6 +185,8 @@ For source-only changes, use the checks that match the blast radius:
 ./tools/test_dependency_parsing.sh
 ./tools/test_issue_10_regression.sh
 ./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
 ./tools/test_support_bundle_sanitization.sh
 ./tools/test_backup_saves_regression.sh
 ./tools/test_launcher_friction.sh

--- a/docs/design/runtime-contracts.md
+++ b/docs/design/runtime-contracts.md
@@ -168,9 +168,10 @@ Diagnostics and reports must not expose secrets, private account data, or
 unredacted sensitive config values. Diagnostics output should be sanitized by
 default for issue reporting. Support bundles should sanitize the diagnostics
 report, include macOS version, Rosetta package version when available, x86_64
-execution status, Qt package verification details, and backup manifests when
-available instead of copying full game or save contents. Support bundles must
-not include raw `.log`, `.trace`, crash-log, save, game-binary, or private
+execution status, sanitized installer history, runtime invariant status, Qt
+package verification details, backup integrity status, and backup manifests
+when available instead of copying full game or save contents. Support bundles
+must not include raw `.log`, `.trace`, crash-log, save, game-binary, or private
 config-file contents. Support-bundle archives should normalize tar owner/group
 metadata so archive listings do not expose local account names.
 The friendly launcher's support option should delegate to

--- a/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
+++ b/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
@@ -42,8 +42,8 @@ Out of scope:
 - Treat `GAME_APP`, `INSTALL_DIR`, `INSTALL_REF`, `LOG_FILE`, and `QT_PREFIX`
   as untrusted input.
 - Keep paths quoted and compatible with `Worms W.M.D.app`.
-- Preserve macOS 26+ behavior and name Windows 11 or macOS runtime gaps when
-  not live-checked.
+- Preserve macOS 26+ runtime behavior and name unavailable macOS/game-source
+  validation gaps when not live-checked.
 - Do not overclaim live-game verification when a real Worms W.M.D installation
   is not available in this session.
 
@@ -220,5 +220,5 @@ LOG_FILE=/tmp/wormswmd-release-artifact-launch.log ./tools/launch_worms.sh --che
 ```
 
 The LaunchAgent was installed in the real user session for the test and then
-uninstalled. No real GOG install, Windows 11 host, macOS 26.0.1 M1 Air, or
-Intel Homebrew Qt fallback was available on this machine.
+uninstalled. No real GOG install, macOS 26.0.1 M1 Air, or Intel Homebrew Qt
+fallback was available on this machine.

--- a/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
+++ b/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
@@ -1,0 +1,224 @@
+# Full Repository Deep Audit
+
+Status: Completed
+
+## Problem
+
+A new issue exposed a partial-install failure class, but the deeper risk is
+repo-wide: other installer, launcher, diagnostics, backup, release, CI, or docs
+paths may still have swallowed failures, misleading success states, rollback
+gaps, privacy leaks, unsafe file handling, platform regressions, or untested
+assumptions. This audit reviews all high-risk surfaces, not just issue #12.
+
+## Scope and non-goals
+
+In scope:
+
+- `install.sh`, `Install Fix.command`, `Worms W.M.D Fix.command`, and
+  `fix_worms_wmd.sh`.
+- `scripts/*.sh`, `tools/*.sh`, CI workflows, release packaging, Qt package
+  handling, AGL build/install, dependency copying, install-name rewriting,
+  verification, restore, backup, diagnostics, preflight, update checks, support
+  bundle privacy, docs/runtime contracts, and issue templates.
+- Current uncommitted changes from the issue #12 pass.
+- Requested specialist agents:
+  `adversarial-reviewer`, `shell-expert`, and `code-reviewer`.
+- Code, test, docs, and plan updates for material findings.
+
+Out of scope:
+
+- Publishing a release, pushing commits, closing GitHub issues, or changing
+  cloud/vendor state without maintainer approval.
+- Replacing the Qt archive in `dist/` unless the audit proves it is actually
+  invalid.
+- Broad refactors or new dependencies that are not needed to fix concrete
+  findings.
+
+## Constraints and risks
+
+- Preserve user game data and the existing backup/rollback story.
+- Keep downloads HTTPS-only and checksum-verified for executable code,
+  frameworks, libraries, and archives.
+- Treat `GAME_APP`, `INSTALL_DIR`, `INSTALL_REF`, `LOG_FILE`, and `QT_PREFIX`
+  as untrusted input.
+- Keep paths quoted and compatible with `Worms W.M.D.app`.
+- Preserve macOS 26+ behavior and name Windows 11 or macOS runtime gaps when
+  not live-checked.
+- Do not overclaim live-game verification when a real Worms W.M.D installation
+  is not available in this session.
+
+## Milestones
+
+- [x] Milestone 1: Load requested skills and redirect requested specialist
+  agents to full-repo scope.
+- [x] Milestone 2: Locally map high-risk workflows and failure surfaces.
+- [x] Milestone 3: Reconcile specialist findings and patch material gaps.
+- [x] Milestone 4: Run focused and broader verification, then record evidence.
+
+## Verification
+
+Focused checks will depend on findings. Baseline checks:
+
+```bash
+./tools/validate_harness.sh
+./tools/test_dependency_parsing.sh
+./tools/test_issue_10_regression.sh
+./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
+./tools/test_support_bundle_sanitization.sh
+./tools/test_backup_saves_regression.sh
+./tools/test_launcher_friction.sh
+./tools/test_preflight_regression.sh
+./tools/test_manifest_regression.sh
+./tools/test_qt_version_pinning.sh
+./scripts/download_qt_frameworks.sh --check
+for script in fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh; do bash -n "$script"; done
+shellcheck fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh
+```
+
+Runtime checks to name if still unavailable:
+
+```bash
+./fix_worms_wmd.sh --verify
+./tools/preflight_check.sh
+./tools/collect_diagnostics.sh
+```
+
+## Progress
+
+- 2026-06-29: User expanded scope from issue #12 to all repo behavior.
+- 2026-06-29: Loaded `adversarial-review`, `shell`, `debug-session`, and
+  `code-review` skills plus shell/debug/code-review references.
+- 2026-06-29: Interrupted and redirected read-only `adversarial-reviewer`,
+  `shell-expert`, and `code-reviewer` agents to full-repo audit scope.
+- 2026-06-29: Reconciled specialist findings. Material blockers were false
+  success on partial Qt/AGL runtime installs, Bash 3.2 rollback trap inheritance,
+  incomplete prebuilt dependency checks, helper failures hidden as success,
+  watcher reapply losing custom `GAME_APP`, and save restore merging stale files.
+- 2026-06-29: Patched runtime preflight/verification, top-level rollback,
+  dependency verification, watcher LaunchAgent path persistence, save restore,
+  diagnostics, and manual install docs. Added regression coverage for rollback,
+  required plugins/dependencies, AGL architecture, custom watcher paths, and exact
+  save restore.
+- 2026-06-29: Ran focused and broader validation before real-machine testing.
+- 2026-06-29: Real `./fix_worms_wmd.sh --force` against the installed game on
+  macOS 27 initially failed while building the x86_64 AGL stub because
+  `arch -x86_64 clang` could not load the arm64-only Command Line Tools
+  `libxcrun`. Rollback restored the app cleanly. Patched
+  `scripts/01_build_agl_stub.sh` to use native `clang -arch x86_64`
+  cross-compilation and added coverage to the issue #12 regression.
+- 2026-06-29: Re-ran real `./fix_worms_wmd.sh --force`; it completed
+  successfully, created `~/Documents/WormsWMD-Backup-20260629-152601`,
+  verified the app, launched the game through `tools/launch_worms.sh --check-fix
+  --log --no-crash-report`, observed a live Worms process, found no recent
+  Worms crash report, and terminated the test-launched process.
+- 2026-06-29: Built a real local release zip, verified its `.sha256`, extracted
+  it, and ran the packaged installer against the live Steam game. The first
+  artifact run exposed stale nested AGL framework symlinks from repeated
+  installs. Added AGL symlink replacement and backup-copy self-heal coverage,
+  rebuilt the zip, and confirmed packaged forced install, diagnostics, launcher
+  readiness, LaunchAgent install/check/uninstall, endpoint checks, and bounded
+  launch all pass.
+
+## Surprises & Discoveries
+
+- `ERR` traps in Bash 3.2 do not fire inside functions unless errtrace is
+  enabled. The installer did almost all mutating work inside `do_fix()`.
+- The original root-cause class was broader than missing AGL: any missing
+  required Qt framework, plugin, dependency, or AGL x86_64 slice could still
+  produce misleading readiness or completion signals.
+- The documented manual helper-by-helper install path bypassed the canonical
+  backup/rollback engine.
+- Save restore needed exact restore semantics, not merge semantics, to remove
+  corrupt or newer files absent from the selected backup.
+- On macOS 27 Apple Silicon, Command Line Tools can cross-compile x86_64 with
+  native `clang -arch x86_64`; forcing the compiler itself through Rosetta can
+  fail because `libxcrun` is not available as x86_64.
+- Repeated AGL framework installs need to remove existing framework symlinks
+  before recreating them. On macOS, `ln -sf` can follow an existing symlink to a
+  directory and create nested links such as `Versions/A/A` or
+  `Versions/A/Resources/Resources`.
+
+## Decision Log
+
+- Keep specialists read-only. Integration and final judgment stay local so
+  findings are verified against the live repo before edits.
+- Treat issue #12 as a symptom and regression seed, not the audit boundary.
+- Preserve the canonical installer as the user recovery path. Manual docs should
+  drive `fix_worms_wmd.sh`, not direct mutating helper scripts.
+- Prefer hard failure plus rollback for required runtime completeness and safety
+  helper failures. Optional signing/quarantine friction can remain warnings.
+- Save restore should copy into a temporary tree first, then replace backed-up
+  save roots and verify stale files did not survive.
+- Repair stale AGL framework symlinks in the backup copy before manifest
+  validation. This preserves backup validation while giving users a self-heal
+  path from older repeated installs.
+
+## Outcomes & Retrospective
+
+The audit found and fixed the broader root-cause class behind issue #12:
+misleading success states after incomplete runtime installation or failed
+recovery paths. The installer now inherits `ERR` traps inside functions so
+post-backup failures roll back on Bash 3.2, required Qt framework/plugin source
+is validated before destructive replacement, prebuilt dependency copies require
+the expected dylib set, AGL readiness requires an x86_64 binary, and optional
+helper failures no longer print false success. Watcher reapply preserves custom
+`GAME_APP`, save restore replaces backed-up roots from a temporary copy and
+checks for stale files, and manual docs now route users through the canonical
+rollback-aware engine.
+
+The artifact validation pass also found and fixed a repeated-install AGL
+framework layout bug: stale framework symlinks are now removed before they are
+recreated, and backup manifest creation repairs the fixer's own stale AGL
+symlinks in the backup copy before validation.
+
+Verification passed on 2026-06-29:
+
+```bash
+./tools/validate_harness.sh
+./tools/test_dependency_parsing.sh
+./tools/test_issue_10_regression.sh
+./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
+./tools/test_support_bundle_sanitization.sh
+./tools/test_backup_saves_regression.sh
+./tools/test_launcher_friction.sh
+./tools/test_preflight_regression.sh
+./tools/test_manifest_regression.sh
+./tools/test_qt_version_pinning.sh
+./scripts/download_qt_frameworks.sh --check
+for script in fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh; do bash -n "$script"; done
+shellcheck fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh
+./tools/build_release_bundle.sh --version local-audit --skip-zip
+clang -Wall -Wextra -Werror -arch x86_64 -dynamiclib -o /tmp/AGL_test -framework OpenGL src/agl_stub.c
+./fix_worms_wmd.sh --help
+./fix_worms_wmd.sh --dry-run
+git diff --check
+```
+
+`./tools/build_release_bundle.sh --version local-audit --skip-zip` generated
+`build/release/WormsWMD-macOS-Fix-local-audit`; that local artifact was removed
+after verification. Later real-machine validation found and fixed the AGL build
+issue above. Real installed-game verification, forced reapply, diagnostics, and
+bounded launch testing passed. A later packaged artifact pass ran:
+
+```bash
+./tools/build_release_bundle.sh --version local-live
+shasum -a 256 -c WormsWMD-macOS-Fix-local-live.zip.sha256
+unzip -q WormsWMD-macOS-Fix-local-live.zip
+./fix_worms_wmd.sh --force
+./fix_worms_wmd.sh --verify --verbose
+./tools/preflight_check.sh
+./tools/collect_diagnostics.sh --output /tmp/wormswmd-after-release-artifact-diagnostics.txt
+printf '3\n\nq\n' | ./Worms\ W.M.D\ Fix.command
+./tools/watch_for_updates.sh --install
+./tools/watch_for_updates.sh --check
+./tools/watch_for_updates.sh --uninstall
+LOG_FILE=/tmp/wormswmd-release-artifact-launch.log ./tools/launch_worms.sh --check-fix --log --no-crash-report
+```
+
+The LaunchAgent was installed in the real user session for the test and then
+uninstalled. No real GOG install, Windows 11 host, macOS 26.0.1 M1 Air, or
+Intel Homebrew Qt fallback was available on this machine.

--- a/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
+++ b/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
@@ -125,8 +125,9 @@ Runtime checks to name if still unavailable:
 
 - `ERR` traps in Bash 3.2 do not fire inside functions unless errtrace is
   enabled. The installer did almost all mutating work inside `do_fix()`.
-- The original root-cause class was broader than missing AGL: any missing
-  required Qt framework, plugin, dependency, or AGL x86_64 slice could still
+- The original root-cause class was broader than missing AGL: required runtime
+  assets supplied by the fixer were not consistently enforced as invariants, so
+  an incomplete artifact, cache, build output, or selected Qt source could still
   produce misleading readiness or completion signals.
 - The documented manual helper-by-helper install path bypassed the canonical
   backup/rollback engine.
@@ -162,8 +163,9 @@ misleading success states after incomplete runtime installation or failed
 recovery paths. The installer now inherits `ERR` traps inside functions so
 post-backup failures roll back on Bash 3.2, required Qt framework/plugin source
 is validated before destructive replacement, prebuilt dependency copies require
-the expected dylib set, AGL readiness requires an x86_64 binary, and optional
-helper failures no longer print false success. Watcher reapply preserves custom
+the expected dylib set, AGL readiness requires an x86_64 binary, and incomplete
+fixer-supplied runtime assets are treated as installer invariant violations.
+Optional helper failures no longer print false success. Watcher reapply preserves custom
 `GAME_APP`, save restore replaces backed-up roots from a temporary copy and
 checks for stale files, and manual docs now route users through the canonical
 rollback-aware engine.

--- a/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
+++ b/docs/exec-plans/2026-06-29-full-repo-deep-audit.md
@@ -120,6 +120,15 @@ Runtime checks to name if still unavailable:
   rebuilt the zip, and confirmed packaged forced install, diagnostics, launcher
   readiness, LaunchAgent install/check/uninstall, endpoint checks, and bounded
   launch all pass.
+- 2026-06-29: Reviewed the issue #12 pasted support bundle for missing future
+  troubleshooting evidence. Added sanitized support-bundle sections for
+  installer history, runtime invariant status, backup integrity status, and
+  required Qt archive contents so future reports show both the immediate error
+  and whether the fixer-supplied runtime assets were present.
+- 2026-06-29: Real support-bundle smoke testing exposed that simultaneous
+  installer commands could reuse a timestamp-only log path and mix timelines.
+  Added process-specific default log names with collision suffixing and
+  regression coverage.
 
 ## Surprises & Discoveries
 
@@ -174,6 +183,14 @@ The artifact validation pass also found and fixed a repeated-install AGL
 framework layout bug: stale framework symlinks are now removed before they are
 recreated, and backup manifest creation repairs the fixer's own stale AGL
 symlinks in the backup copy before validation.
+
+The support-bundle follow-up closes an observability gap from issue #12. Future
+bundles now include sanitized install-log summaries, the selected fix version or
+commit, a runtime invariant matrix for AGL, Qt frameworks, Qt plugins, bundled
+dylibs, backup integrity status, and required Qt archive content checks without
+copying raw logs, saves, game binaries, or private config contents.
+Default installer logs now include the process ID plus a suffix on collision, so
+same-second verify/dry-run/apply invocations do not mix into one log file.
 
 Verification passed on 2026-06-29:
 

--- a/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
+++ b/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
@@ -1,0 +1,168 @@
+# Issue 12 AGL Stub Install Failure
+
+Status: Completed
+
+## Problem
+
+Issue #12 reports a release-zip launcher install on macOS 26.0.1 where the
+game still launches to a black screen and diagnostics show `AGL stub NOT
+installed`. The attached diagnostics also show the game bundle can be left in a
+partially fixed state.
+
+## Scope and non-goals
+
+In scope:
+
+- Inspect the AGL build/install path in `fix_worms_wmd.sh` and
+  `scripts/04_fix_library_paths.sh`.
+- Inspect the required Qt framework replacement path in
+  `scripts/02_replace_qt_frameworks.sh`.
+- Add the smallest regression checks that catch missing built AGL stubs during
+  install-name repair, missing required Qt framework/plugin source during
+  replacement, non-x86_64 AGL stubs, and incomplete prebuilt dependency copies.
+- Update troubleshooting or support text if the user-facing recovery path is
+  unclear.
+
+Out of scope:
+
+- Replacing the Qt archive in `dist/`.
+- Changing game discovery, backup format, release packaging, or launcher menu
+  structure.
+- Adding privileged operations or new dependencies.
+
+## Constraints and risks
+
+- Preserve user game data and the existing backup/rollback path.
+- Keep behavior portable across Windows 11 repository checks and macOS 26+
+  runtime behavior. macOS-specific runtime checks may be named if not live-run.
+- Treat `GAME_APP` and `BUILD_DIR` as untrusted input and keep all paths quoted.
+- Do not make a missing AGL stub look successful. A partial install must fail
+  clearly and allow rollback.
+
+## Milestones
+
+- [x] Milestone 1: Inspect issue #12, current docs, active plans, and the AGL
+  build/install scripts.
+- [x] Milestone 2: Patch the minimal failure paths so missing `$BUILD_DIR/AGL`,
+  missing required Qt source, missing Qt plugins, non-x86_64 AGL stubs, and
+  incomplete prebuilt dependencies abort instead of continuing.
+- [x] Milestone 3: Add focused regression checks and necessary user-facing
+  recovery notes.
+- [x] Milestone 4: Run targeted verification and record the evidence.
+
+## Verification
+
+Focused checks:
+
+```bash
+./tools/test_issue_12_agl_install_failure.sh
+bash -n scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh scripts/04_fix_library_paths.sh scripts/05_verify_installation.sh tools/test_issue_12_agl_install_failure.sh
+```
+
+Broader checks if shell or docs behavior changes:
+
+```bash
+./tools/validate_harness.sh
+shellcheck scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh scripts/04_fix_library_paths.sh scripts/05_verify_installation.sh tools/test_issue_12_agl_install_failure.sh
+```
+
+## Progress
+
+- 2026-06-29: Created plan after issue triage. Issue #12 diagnostics show
+  missing AGL, missing QtDBus/QtSvg, and one backup directory on an M1 macOS
+  26.0.1 Steam install.
+- 2026-06-29: Patched `scripts/04_fix_library_paths.sh`, added
+  `tools/test_issue_12_agl_install_failure.sh`, updated validation indexes, and
+  added troubleshooting guidance for the missing AGL diagnostic.
+- 2026-06-29: Added the issue #12 regression check to the CI workflow.
+- 2026-06-29: Extended the root-cause fix to
+  `scripts/02_replace_qt_frameworks.sh` so missing required Qt framework source
+  also fails before the install can continue.
+- 2026-06-29: Extended the regression to required Qt plugins, prebuilt
+  dependency completeness, verifier-required plugins, and AGL x86_64
+  architecture checks.
+- 2026-06-29: Real macOS 27 forced reapply found that `arch -x86_64 clang`
+  cannot load arm64-only Command Line Tools `libxcrun`; switched the AGL build
+  script to native `clang -arch x86_64` cross-compilation.
+- 2026-06-29: Re-ran real forced install after the AGL build patch; install,
+  verification, diagnostics, and bounded launch testing passed against the
+  local Steam game install.
+- 2026-06-29: Release-zip artifact testing found repeated installs could leave
+  stale nested AGL framework symlinks that failed backup manifest validation.
+  Patched AGL symlink replacement and backup-copy self-heal, then reran the
+  packaged forced install successfully.
+
+## Surprises & Discoveries
+
+- `scripts/04_fix_library_paths.sh` validates that `BUILD_DIR` is set, but if
+  `$BUILD_DIR/AGL` is absent it only prints a warning and continues.
+- `scripts/02_replace_qt_frameworks.sh` previously printed a warning and
+  continued when required Qt frameworks such as `QtDBus` or `QtSvg` were absent
+  from the selected Qt source.
+- Required Qt plugin source and prebuilt dependency completeness were also part
+  of the same partial-install failure class.
+- The AGL build step itself must not run `clang` under Rosetta. Native clang can
+  cross-compile the required x86_64 slice without requiring x86_64 `libxcrun`.
+- Repeated AGL installs must remove existing framework symlinks before
+  recreating them; `ln -sf` is not enough on macOS when the destination is an
+  existing symlink to a directory.
+
+## Decision Log
+
+- Use a hard failure for a missing built AGL stub during library-path fixing.
+  This preserves the installer contract and lets the existing rollback trap
+  restore the pre-fix bundle instead of leaving a known black-screen state.
+- Use a hard failure for missing required Qt framework source during
+  replacement. A missing Qt runtime component is not optional for the current
+  fix contract.
+- Treat missing `libqcocoa.dylib`, missing `libqsvg.dylib`, missing required
+  bundled dylibs, and AGL binaries without an x86_64 slice as install blockers.
+- Build AGL slices with native `clang -arch ...`; reserve Rosetta for running
+  the Intel game, not for running Apple developer tooling.
+- Repair stale AGL framework symlinks in backup copies before manifest
+  validation so users affected by older repeated installs can self-heal by
+  rerunning the latest fixer.
+
+## Outcomes & Retrospective
+
+The library path fixer now exits with an error when `$BUILD_DIR/AGL` is missing
+instead of continuing to a partial install. The Qt replacement script now exits
+with an error when required framework source such as `QtSvg.framework` or
+required plugin source such as `libqcocoa.dylib`/`libqsvg.dylib` is missing. The
+dependency copy step now verifies the required prebuilt dylib set, and
+verification/preflight treat non-x86_64 AGL stubs and missing required plugins
+as errors. The issue #12 regression check creates fake game bundles for these
+cases and verifies the scripts fail before claiming the install step is
+complete. It also checks repeated AGL framework replacement does not create
+nested framework symlinks. CI now runs that check with the other repository
+regression scripts.
+
+Verification passed on 2026-06-29:
+
+```bash
+./tools/test_issue_12_agl_install_failure.sh
+bash -n scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh scripts/04_fix_library_paths.sh scripts/05_verify_installation.sh tools/test_issue_12_agl_install_failure.sh
+./tools/validate_harness.sh
+shellcheck scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh scripts/04_fix_library_paths.sh scripts/05_verify_installation.sh tools/test_issue_12_agl_install_failure.sh
+./tools/test_qt_version_pinning.sh
+./scripts/download_qt_frameworks.sh --check
+tar -tzf dist/qt-frameworks-x86_64-5.15.19.tar.gz | rg -q '^Frameworks/QtDBus\.framework/' && tar -tzf dist/qt-frameworks-x86_64-5.15.19.tar.gz | rg -q '^Frameworks/QtSvg\.framework/'
+for script in fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh; do bash -n "$script"; done
+shellcheck fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh
+```
+
+Real installed-game validation also passed on 2026-06-29:
+
+```bash
+./tools/preflight_check.sh --quick
+./fix_worms_wmd.sh --verify --verbose
+./tools/collect_diagnostics.sh --output /tmp/wormswmd-real-validation-diagnostics.txt
+./fix_worms_wmd.sh --force
+./fix_worms_wmd.sh --verify
+./tools/preflight_check.sh
+./tools/collect_diagnostics.sh --output /tmp/wormswmd-real-validation-postfix-diagnostics.txt
+LOG_FILE=/tmp/wormswmd-real-launch.log ./tools/launch_worms.sh --check-fix --log --no-crash-report
+```
+
+The bounded launch test observed a live Worms process after Steam handoff,
+found no recent Worms crash report, and terminated the test-launched process.

--- a/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
+++ b/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
@@ -33,8 +33,9 @@ Out of scope:
 ## Constraints and risks
 
 - Preserve user game data and the existing backup/rollback path.
-- Keep behavior portable across Windows 11 repository checks and macOS 26+
-  runtime behavior. macOS-specific runtime checks may be named if not live-run.
+- Keep behavior portable across the repo's shell/documentation checks and
+  preserve macOS 26+ runtime behavior. macOS-specific runtime checks may be
+  named if not live-run.
 - Treat `GAME_APP` and `BUILD_DIR` as untrusted input and keep all paths quoted.
 - Do not make a missing AGL stub look successful. A partial install must fail
   clearly and allow rollback.

--- a/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
+++ b/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
@@ -94,6 +94,10 @@ shellcheck scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh s
   stale nested AGL framework symlinks that failed backup manifest validation.
   Patched AGL symlink replacement and backup-copy self-heal, then reran the
   packaged forced install successfully.
+- 2026-06-29: Reviewed the pasted support bundle for missing future
+  troubleshooting evidence. Added sanitized support-bundle sections for
+  installer history, runtime invariant status, backup integrity status, and
+  required Qt archive contents.
 
 ## Surprises & Discoveries
 
@@ -170,3 +174,9 @@ LOG_FILE=/tmp/wormswmd-real-launch.log ./tools/launch_worms.sh --check-fix --log
 
 The bounded launch test observed a live Worms process after Steam handoff,
 found no recent Worms crash report, and terminated the test-launched process.
+
+Support-bundle observability was also expanded after reviewing issue #12. Future
+bundles show the selected fix version or commit, recent installer outcomes and
+step timeline, AGL/Qt/plugin/dylib runtime invariant status, backup integrity
+status, and required Qt archive content checks without copying raw logs, saves,
+game binaries, or private config contents.

--- a/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
+++ b/docs/exec-plans/2026-06-29-issue-12-agl-stub-install.md
@@ -37,7 +37,9 @@ Out of scope:
   preserve macOS 26+ runtime behavior. macOS-specific runtime checks may be
   named if not live-run.
 - Treat `GAME_APP` and `BUILD_DIR` as untrusted input and keep all paths quoted.
-- Do not make a missing AGL stub look successful. A partial install must fail
+- Do not make a missing AGL stub look successful. The fixer is responsible for
+  supplying the AGL/Qt runtime assets; if a release artifact, cache, build
+  output, or selected Qt source cannot supply them, the install must fail
   clearly and allow rollback.
 
 ## Milestones
@@ -111,10 +113,11 @@ shellcheck scripts/02_replace_qt_frameworks.sh scripts/03_copy_dependencies.sh s
 ## Decision Log
 
 - Use a hard failure for a missing built AGL stub during library-path fixing.
-  This preserves the installer contract and lets the existing rollback trap
-  restore the pre-fix bundle instead of leaving a known black-screen state.
+  The build step is responsible for supplying it; absence means the installer
+  invariant is broken and rollback should restore the pre-fix bundle.
 - Use a hard failure for missing required Qt framework source during
-  replacement. A missing Qt runtime component is not optional for the current
+  replacement. The release artifact or selected Qt source is responsible for
+  supplying it; a missing Qt runtime component is not optional for the current
   fix contract.
 - Treat missing `libqcocoa.dylib`, missing `libqsvg.dylib`, missing required
   bundled dylibs, and AGL binaries without an x86_64 slice as install blockers.
@@ -132,11 +135,11 @@ with an error when required framework source such as `QtSvg.framework` or
 required plugin source such as `libqcocoa.dylib`/`libqsvg.dylib` is missing. The
 dependency copy step now verifies the required prebuilt dylib set, and
 verification/preflight treat non-x86_64 AGL stubs and missing required plugins
-as errors. The issue #12 regression check creates fake game bundles for these
-cases and verifies the scripts fail before claiming the install step is
-complete. It also checks repeated AGL framework replacement does not create
-nested framework symlinks. CI now runs that check with the other repository
-regression scripts.
+as installer invariant failures. The issue #12 regression check creates fake
+game bundles for these cases and verifies the scripts fail before claiming the
+install step is complete. It also checks repeated AGL framework replacement
+does not create nested framework symlinks. CI now runs that check with the
+other repository regression scripts.
 
 Verification passed on 2026-06-29:
 

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -31,6 +31,11 @@ the plan before continuing.
 
 ## Current Plans
 
+- [Full repository deep audit](2026-06-29-full-repo-deep-audit.md) - completed
+  repo-wide audit of installer, launcher, diagnostics, backup, release, CI, and
+  documentation behavior.
+- [Issue 12 AGL stub install failure](2026-06-29-issue-12-agl-stub-install.md) - completed
+  fix for missing AGL and required Qt runtime partial installs.
 - [macOS 27 Golden Gate compatibility](2026-06-22-macos-27-golden-gate.md) - completed
   full-repo compatibility and release-gate pass for macOS 27.
 - [Issue 11 game detection](2026-06-22-issue-11-game-detection.md) - completed

--- a/docs/runbooks/agent-session.md
+++ b/docs/runbooks/agent-session.md
@@ -54,6 +54,8 @@ Release publication:
 ./tools/test_dependency_parsing.sh
 ./tools/test_issue_10_regression.sh
 ./tools/test_issue_11_game_detection.sh
+./tools/test_issue_12_agl_install_failure.sh
+./tools/test_installer_rollback_regression.sh
 ./tools/test_support_bundle_sanitization.sh
 ./tools/test_backup_saves_regression.sh
 ./tools/test_launcher_friction.sh

--- a/fix_worms_wmd.sh
+++ b/fix_worms_wmd.sh
@@ -21,7 +21,7 @@
 #   - Pre-built Qt frameworks are downloaded automatically
 #
 
-set -euo pipefail
+set -Eeuo pipefail
 
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 while [[ -L "$SCRIPT_PATH" ]]; do
@@ -400,6 +400,7 @@ cleanup() {
 write_game_backup_manifest() {
     local backup_dir="$1"
 
+    worms_repair_agl_framework_symlinks "$backup_dir"
     worms_validate_tree_symlinks "$backup_dir"
     worms_write_manifest "$backup_dir" "$backup_dir/$BACKUP_MANIFEST_NAME" \
         Frameworks \
@@ -785,9 +786,12 @@ detect_qt_source() {
 
 check_already_applied() {
     local game_frameworks="$GAME_APP/Contents/Frameworks"
+    local game_plugins="$GAME_APP/Contents/PlugIns"
     local has_agl=false
     local has_qt=false
     local has_deps=false
+    local has_required_runtime=true
+    local required_fw
 
     # Check for AGL stub
     if [[ -f "$game_frameworks/AGL.framework/Versions/A/AGL" ]]; then
@@ -828,7 +832,18 @@ check_already_applied() {
         has_deps=true
     fi
 
-    if $has_agl && $has_qt && $has_deps; then
+    for required_fw in QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg; do
+        if [[ ! -d "$game_frameworks/$required_fw.framework" ]]; then
+            has_required_runtime=false
+            break
+        fi
+    done
+    if [[ ! -f "$game_plugins/platforms/libqcocoa.dylib" ]] \
+        || [[ ! -f "$game_plugins/imageformats/libqsvg.dylib" ]]; then
+        has_required_runtime=false
+    fi
+
+    if $has_agl && $has_qt && $has_deps && $has_required_runtime; then
         echo "yes"
     elif $has_agl || $has_qt || $has_deps; then
         echo "partial"
@@ -1359,15 +1374,31 @@ do_fix() {
     # Fix Info.plist
     if [[ -f "$SCRIPTS_DIR/06_fix_info_plist.sh" ]]; then
         chmod +x "$SCRIPTS_DIR/06_fix_info_plist.sh"
-        "$SCRIPTS_DIR/06_fix_info_plist.sh" > /dev/null 2>&1 || true
-        print_substep "Info.plist updated (bundle ID, HiDPI, min version)"
+        local info_plist_output
+        if info_plist_output=$("$SCRIPTS_DIR/06_fix_info_plist.sh" 2>&1); then
+            print_substep "Info.plist updated (bundle ID, HiDPI, min version)"
+        else
+            print_error "Info.plist update failed"
+            echo "$info_plist_output" | head -5 | while read -r line; do
+                [[ -n "$line" ]] && print_substep "$line"
+            done || true
+            return 1
+        fi
     fi
 
     # Fix config URLs
     if [[ -f "$SCRIPTS_DIR/07_fix_config_urls.sh" ]]; then
         chmod +x "$SCRIPTS_DIR/07_fix_config_urls.sh"
-        "$SCRIPTS_DIR/07_fix_config_urls.sh" > /dev/null 2>&1 || true
-        print_substep "Config URLs secured (HTTP→HTTPS)"
+        local config_output
+        if config_output=$("$SCRIPTS_DIR/07_fix_config_urls.sh" 2>&1); then
+            print_substep "Config URLs secured (HTTP→HTTPS)"
+        else
+            print_error "Config URL update failed"
+            echo "$config_output" | head -5 | while read -r line; do
+                [[ -n "$line" ]] && print_substep "$line"
+            done || true
+            return 1
+        fi
     fi
 
     # ============================================================

--- a/scripts/01_build_agl_stub.sh
+++ b/scripts/01_build_agl_stub.sh
@@ -41,7 +41,7 @@ mkdir -p "$BUILD_DIR"
 
 # Compile for x86_64 (required for Rosetta 2 compatibility)
 echo "Compiling agl_stub.c for x86_64..."
-arch -x86_64 clang -arch x86_64 \
+clang -arch x86_64 \
     -dynamiclib \
     -o "$BUILD_DIR/AGL_x86_64" \
     -install_name "@executable_path/../Frameworks/AGL.framework/Versions/A/AGL" \

--- a/scripts/02_replace_qt_frameworks.sh
+++ b/scripts/02_replace_qt_frameworks.sh
@@ -162,11 +162,30 @@ append_unique "QtDBus"
 append_unique "QtSvg"
 
 for fw in "${FRAMEWORKS[@]}"; do
-    if [ ! -d "$NEW_QT/$fw.framework" ]; then
-        echo "WARNING: $fw.framework not found in $NEW_QT"
-        continue
+    source_fw="$NEW_QT/$fw.framework"
+    if [ ! -d "$source_fw" ]; then
+        echo "ERROR: Required Qt framework missing from source: $source_fw"
+        exit 1
     fi
 
+    source_fw_bin=$(worms_framework_binary "$source_fw" "$fw" || true)
+    if [ -z "$source_fw_bin" ] || [ ! -f "$source_fw_bin" ]; then
+        echo "ERROR: Required Qt framework binary missing from source: $source_fw"
+        exit 1
+    fi
+done
+
+if [ ! -f "$NEW_QT_PLUGINS/platforms/libqcocoa.dylib" ]; then
+    echo "ERROR: Required Qt platform plugin missing from source: $NEW_QT_PLUGINS/platforms/libqcocoa.dylib"
+    exit 1
+fi
+
+if [ ! -f "$NEW_QT_PLUGINS/imageformats/libqsvg.dylib" ]; then
+    echo "ERROR: Required Qt image plugin missing from source: $NEW_QT_PLUGINS/imageformats/libqsvg.dylib"
+    exit 1
+fi
+
+for fw in "${FRAMEWORKS[@]}"; do
     echo "Replacing $fw.framework..."
 
     # Remove old framework

--- a/scripts/03_copy_dependencies.sh
+++ b/scripts/03_copy_dependencies.sh
@@ -72,6 +72,35 @@ if [[ "$QT_SOURCE" == "prebuild" ]]; then
         fi
     done
 
+    missing_required=0
+    for required_lib in \
+        libglib-2.0.0.dylib \
+        libgthread-2.0.0.dylib \
+        libintl.8.dylib \
+        libpcre2-16.0.dylib \
+        libpcre2-8.0.dylib \
+        libzstd.1.dylib \
+        libpng16.16.dylib \
+        libjpeg.8.dylib \
+        libfreetype.6.dylib \
+        libmd4c.0.dylib \
+        liblzma.5.dylib \
+        libtiff.6.dylib; do
+        if [[ ! -f "$GAME_FRAMEWORKS/$required_lib" ]]; then
+            echo "ERROR: Required bundled dependency missing: $required_lib"
+            ((++missing_required))
+        fi
+    done
+
+    if [[ $missing_required -gt 0 ]]; then
+        echo ""
+        echo "Pre-built dependency verification failed."
+        echo "Re-run the installer with --force to refresh the Qt package, or install the Homebrew fallback."
+        echo "COPIED_LIBS=$bundled_count"
+        echo "MISSING_LIBS=$missing_required"
+        exit 1
+    fi
+
     if [[ $bundled_count -gt 0 ]]; then
         echo "Found $bundled_count bundled dependencies"
         echo ""

--- a/scripts/04_fix_library_paths.sh
+++ b/scripts/04_fix_library_paths.sh
@@ -92,14 +92,20 @@ if [ -f "$BUILD_DIR/AGL" ]; then
 </dict>
 </plist>
 EOF
-    rm -f "$GAME_FRAMEWORKS/AGL.framework/Versions/A/A"
+    rm -f \
+        "$GAME_FRAMEWORKS/AGL.framework/AGL" \
+        "$GAME_FRAMEWORKS/AGL.framework/Resources" \
+        "$GAME_FRAMEWORKS/AGL.framework/Versions/Current" \
+        "$GAME_FRAMEWORKS/AGL.framework/Versions/A/A" \
+        "$GAME_FRAMEWORKS/AGL.framework/Versions/A/Resources/Resources"
     ln -sf A "$GAME_FRAMEWORKS/AGL.framework/Versions/Current"
     ln -sf Versions/Current/AGL "$GAME_FRAMEWORKS/AGL.framework/AGL"
     ln -sf Versions/Current/Resources "$GAME_FRAMEWORKS/AGL.framework/Resources"
     echo "AGL stub installed"
 else
-    echo "WARNING: AGL stub not found at $BUILD_DIR/AGL"
-    echo "Run 01_build_agl_stub.sh first"
+    echo "ERROR: AGL stub not found at $BUILD_DIR/AGL"
+    echo "Run 01_build_agl_stub.sh first."
+    exit 1
 fi
 
 fw_names=()

--- a/scripts/05_verify_installation.sh
+++ b/scripts/05_verify_installation.sh
@@ -195,6 +195,21 @@ fi
 echo ""
 echo "--- Checking frameworks ---"
 framework_found=false
+for required_fw in QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg; do
+    required_fw_dir="$GAME_FRAMEWORKS/$required_fw.framework"
+    if [ ! -d "$required_fw_dir" ]; then
+        echo "ERROR: Required framework missing: $required_fw.framework"
+        ((errors++))
+        continue
+    fi
+
+    required_fw_bin=$(worms_framework_binary "$required_fw_dir" "$required_fw" || true)
+    if [ -z "$required_fw_bin" ] || [ ! -f "$required_fw_bin" ]; then
+        echo "ERROR: Required framework binary missing: $required_fw.framework"
+        ((errors++))
+    fi
+done
+
 for fw_dir in "$GAME_FRAMEWORKS"/*.framework; do
     if [ -d "$fw_dir" ]; then
         fw_name=$(basename "$fw_dir" .framework)
@@ -247,14 +262,14 @@ if [ ! -f "$GAME_FRAMEWORKS/AGL.framework/Versions/A/AGL" ]; then
     echo "ERROR: AGL stub not found!"
     ((errors++))
 else
-    arch=$(lipo -archs "$GAME_FRAMEWORKS/AGL.framework/Versions/A/AGL" 2>/dev/null)
+    arch=$(lipo -archs "$GAME_FRAMEWORKS/AGL.framework/Versions/A/AGL" 2>/dev/null || true)
     if [ "$arch" = "x86_64" ]; then
         echo "OK: AGL stub (x86_64)"
     elif echo "$arch" | grep -q "x86_64" && echo "$arch" | grep -q "arm64"; then
         echo "OK: AGL stub (universal: $arch)"
     else
-        echo "WARNING: AGL stub architecture is $arch (expected x86_64 or universal)"
-        ((warnings++))
+        echo "ERROR: AGL stub architecture is ${arch:-unknown} (expected x86_64 or universal)"
+        ((errors++))
     fi
     print_deps "$GAME_FRAMEWORKS/AGL.framework/Versions/A/AGL" "AGL stub"
 fi
@@ -276,6 +291,14 @@ echo "OK: Library dependencies checked"
 # Check plugins
 echo ""
 echo "--- Checking plugins ---"
+if [ ! -f "$GAME_PLUGINS/platforms/libqcocoa.dylib" ]; then
+    echo "ERROR: Required platform plugin missing: platforms/libqcocoa.dylib"
+    ((errors++))
+fi
+if [ ! -f "$GAME_PLUGINS/imageformats/libqsvg.dylib" ]; then
+    echo "ERROR: Required image plugin missing: imageformats/libqsvg.dylib"
+    ((errors++))
+fi
 for plugin in "$GAME_PLUGINS/platforms/"*.dylib "$GAME_PLUGINS/imageformats/"*.dylib; do
     if [ -f "$plugin" ]; then
         name=$(basename "$plugin")

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -356,6 +356,31 @@ worms_validate_tree_symlinks() {
     return "$status"
 }
 
+worms_repair_agl_framework_symlinks() {
+    local root_dir="$1"
+    local agl_framework="$root_dir/Frameworks/AGL.framework"
+    local link_path
+
+    [[ -d "$agl_framework" ]] || return 0
+    [[ -f "$agl_framework/Versions/A/AGL" ]] || return 0
+
+    for link_path in \
+        "$agl_framework/AGL" \
+        "$agl_framework/Resources" \
+        "$agl_framework/Versions/Current" \
+        "$agl_framework/Versions/A/A" \
+        "$agl_framework/Versions/A/Resources/Resources"; do
+        if [[ -L "$link_path" ]]; then
+            rm -f "$link_path"
+        fi
+    done
+
+    mkdir -p "$agl_framework/Versions/A/Resources"
+    [[ -e "$agl_framework/Versions/Current" ]] || ln -s A "$agl_framework/Versions/Current"
+    [[ -e "$agl_framework/AGL" ]] || ln -s Versions/Current/AGL "$agl_framework/AGL"
+    [[ -e "$agl_framework/Resources" ]] || ln -s Versions/Current/Resources "$agl_framework/Resources"
+}
+
 worms_validate_game_app_for_mutation() {
     local game_app="$1"
     local root_real contents contents_real path path_real

--- a/scripts/logging.sh
+++ b/scripts/logging.sh
@@ -57,6 +57,20 @@ worms_log_path_inside_root() {
     return 1
 }
 
+worms_log_unique_path() {
+    local base="$1"
+    local suffix="$2"
+    local candidate="${base}${suffix}"
+    local counter=1
+
+    while [[ -e "$candidate" ]]; do
+        candidate="${base}-${counter}${suffix}"
+        counter=$((counter + 1))
+    done
+
+    printf '%s\n' "$candidate"
+}
+
 worms_prepare_log_file() {
     local script_name="$1"
     local default_root="$HOME/Library/Logs"
@@ -78,7 +92,7 @@ worms_prepare_log_file() {
     fi
 
     if [[ -z "${LOG_FILE:-}" ]]; then
-        LOG_FILE="$LOG_DIR/${script_name}-${timestamp}.log"
+        LOG_FILE=$(worms_log_unique_path "$LOG_DIR/${script_name}-${timestamp}-$$" ".log")
     fi
 
     case "$LOG_FILE" in

--- a/tools/backup_saves.sh
+++ b/tools/backup_saves.sh
@@ -48,6 +48,16 @@ macos_product_version() {
     sw_vers -productVersion 2>/dev/null || echo "unknown"
 }
 
+restore_assume_yes() {
+    case "${WORMSWMD_RESTORE_ASSUME_YES:-}" in
+        1|true|TRUE|yes|YES|y|Y)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 print_help() {
     cat << 'EOF'
 Worms W.M.D - Save Game Backup Tool
@@ -163,8 +173,12 @@ restore_target_for_manifest_path() {
 verify_restored_saves() {
     local manifest="$TEMP_DIR/$SAVE_MANIFEST_NAME"
     local expected_hash expected_size rel_path target actual_hash actual_size status=0
+    local expected_rel_file actual_rel_file extra_rel user_dir user_id target_dir
 
     [[ -f "$manifest" ]] || return 0
+
+    expected_rel_file=$(mktemp "${TMPDIR:-/tmp}/wormswmd-save-expected.XXXXXX")
+    actual_rel_file=$(mktemp "${TMPDIR:-/tmp}/wormswmd-save-actual.XXXXXX")
 
     while IFS=$'\t' read -r expected_hash expected_size rel_path extra; do
         [[ -n "${expected_hash:-}" ]] || continue
@@ -186,9 +200,58 @@ verify_restored_saves() {
             echo -e "${YELLOW}WARNING:${NC} Restored file does not match backup manifest: $rel_path"
             status=1
         fi
+        printf '%s\n' "$rel_path" >> "$expected_rel_file"
     done < "$manifest"
 
+    if [[ -d "$TEMP_DIR/Team17" ]] && [[ -d "$TEAM17_SAVES" ]]; then
+        (
+            cd "$TEAM17_SAVES" || exit 1
+            find . -type f -print 2>/dev/null | sed 's#^\./#Team17/#'
+        ) >> "$actual_rel_file"
+    fi
+
+    if [[ -d "$TEMP_DIR/Steam" ]]; then
+        for user_dir in "$TEMP_DIR/Steam"/*; do
+            [[ -d "$user_dir" ]] || continue
+            user_id=$(basename "$user_dir")
+            target_dir="$STEAM_SAVES/$user_id/327030"
+            [[ -d "$target_dir" ]] || continue
+            (
+                cd "$target_dir" || exit 1
+                find . -type f -print 2>/dev/null | sed "s#^\./#Steam/$user_id/#"
+            ) >> "$actual_rel_file"
+        done
+    fi
+
+    LC_ALL=C sort -u "$expected_rel_file" -o "$expected_rel_file"
+    LC_ALL=C sort -u "$actual_rel_file" -o "$actual_rel_file"
+    extra_rel=$(comm -13 "$expected_rel_file" "$actual_rel_file" | head -1 || true)
+    if [[ -n "$extra_rel" ]]; then
+        echo -e "${YELLOW}WARNING:${NC} Restore left an unexpected file: $extra_rel"
+        status=1
+    fi
+
+    rm -f "$expected_rel_file" "$actual_rel_file"
+
     return "$status"
+}
+
+replace_save_tree() {
+    local source_dir="$1"
+    local target_dir="$2"
+    local target_parent target_base temp_target
+
+    target_parent=$(dirname "$target_dir")
+    target_base=$(basename "$target_dir")
+
+    mkdir -p "$target_parent"
+    temp_target=$(mktemp -d "$target_parent/.${target_base}.restore.XXXXXX")
+    if ! cp -R "$source_dir/." "$temp_target/"; then
+        rm -rf "$temp_target"
+        return 1
+    fi
+    rm -rf "$target_dir"
+    mv "$temp_target" "$target_dir"
 }
 
 # Create backup
@@ -291,12 +354,16 @@ do_restore() {
 
     echo -e "${YELLOW}WARNING: This will overwrite your current save games!${NC}"
     echo ""
-    read -p "Continue? [y/N] " -n 1 -r < /dev/tty
-    echo ""
+    if restore_assume_yes; then
+        echo "Continuing because WORMSWMD_RESTORE_ASSUME_YES is set."
+    else
+        read -p "Continue? [y/N] " -n 1 -r < /dev/tty
+        echo ""
 
-    if [[ ! "${REPLY:-}" =~ ^[Yy]$ ]]; then
-        echo "Restore cancelled."
-        exit 0
+        if [[ ! "${REPLY:-}" =~ ^[Yy]$ ]]; then
+            echo "Restore cancelled."
+            exit 0
+        fi
     fi
 
     echo ""
@@ -322,8 +389,7 @@ do_restore() {
     # Restore Team17 saves
     if [[ -d "$TEMP_DIR/Team17" ]]; then
         echo "Restoring Team17 saves..."
-        mkdir -p "$TEAM17_SAVES"
-        cp -R "$TEMP_DIR/Team17/." "$TEAM17_SAVES/"
+        replace_save_tree "$TEMP_DIR/Team17" "$TEAM17_SAVES"
     fi
 
     # Restore Steam saves
@@ -335,8 +401,7 @@ do_restore() {
                 local target_dir="$STEAM_SAVES/$user_id/327030"
 
                 echo "Restoring Steam saves for user $user_id..."
-                mkdir -p "$target_dir"
-                cp -R "$user_dir/." "$target_dir/"
+                replace_save_tree "$user_dir" "$target_dir"
             fi
         done
     fi

--- a/tools/collect_diagnostics.sh
+++ b/tools/collect_diagnostics.sh
@@ -39,6 +39,33 @@ COPY_TO_CLIPBOARD=false
 SUPPORT_BUNDLE=false
 BUNDLE_OUTPUT_DIR="${BUNDLE_OUTPUT_DIR:-$HOME/Desktop}"
 BUNDLE_TEMP_DIR=""
+REQUIRED_QT_FRAMEWORKS=(
+    QtCore
+    QtGui
+    QtWidgets
+    QtOpenGL
+    QtPrintSupport
+    QtDBus
+    QtSvg
+)
+REQUIRED_QT_PLUGINS=(
+    platforms/libqcocoa.dylib
+    imageformats/libqsvg.dylib
+)
+REQUIRED_BUNDLED_DYLIBS=(
+    libglib-2.0.0.dylib
+    libgthread-2.0.0.dylib
+    libintl.8.dylib
+    libpcre2-16.0.dylib
+    libpcre2-8.0.dylib
+    libzstd.1.dylib
+    libpng16.16.dylib
+    libjpeg.8.dylib
+    libfreetype.6.dylib
+    libmd4c.0.dylib
+    liblzma.5.dylib
+    libtiff.6.dylib
+)
 
 cleanup() {
     if [[ -n "$BUNDLE_TEMP_DIR" ]] && [[ -d "$BUNDLE_TEMP_DIR" ]]; then
@@ -59,6 +86,10 @@ verify_qt_package_checksum() {
     (cd "$package_dir" && shasum -a 256 -c "$checksum_name" >/dev/null 2>&1)
 }
 
+fix_tool_version() {
+    awk -F= '/^VERSION=/{gsub(/"/, "", $2); print $2; exit}' "$REPO_DIR/fix_worms_wmd.sh" 2>/dev/null
+}
+
 sanitize_report() {
     local input="$1"
     local output="$2"
@@ -72,10 +103,50 @@ sanitize_report() {
             gsub(/\/var\/folders\/[^"<>]*/, "[redacted-path]")
             gsub(/\/tmp\/[^"<>]*/, "[redacted-path]")
             gsub(/[[:alnum:]._%+-]+@[[:alnum:].-]+[.][[:alpha:]]{2,}/, "[redacted-email]")
-            gsub(/([Tt]oken|[Ss]ecret|[Pp]assword|[Aa][Pp][Ii][_-]?[Kk]ey)[[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "\\1=[redacted-secret]")
+            gsub(/[Tt][Oo][Kk][Ee][Nn][[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "token=[redacted-secret]")
+            gsub(/[Ss][Ee][Cc][Rr][Ee][Tt][[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "secret=[redacted-secret]")
+            gsub(/[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd][[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "password=[redacted-secret]")
+            gsub(/[Aa][Pp][Ii][_-][Kk][Ee][Yy][[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "api_key=[redacted-secret]")
+            gsub(/[Aa][Pp][Ii][Kk][Ee][Yy][[:space:]]*[:=][[:space:]]*[^[:space:]]+/, "apikey=[redacted-secret]")
             print
         }
     ' "$input" > "$output"
+}
+
+latest_fix_logs() {
+    local log_dir="$HOME/Library/Logs/WormsWMD-Fix"
+    local log_file mtime
+
+    [[ -d "$log_dir" ]] || return 0
+
+    find "$log_dir" -maxdepth 1 -type f -name 'fix_worms_wmd-*.log' -print0 2>/dev/null \
+        | while IFS= read -r -d '' log_file; do
+            mtime=$(stat -f "%m" "$log_file" 2>/dev/null || echo 0)
+            printf '%s\t%s\n' "$mtime" "$log_file"
+        done \
+        | sort -nr \
+        | awk -F '\t' 'NR <= 5 { sub(/^[^\t]*\t/, ""); print }'
+}
+
+infer_log_outcome() {
+    local log_file="$1"
+    local line outcome="unknown"
+
+    while IFS= read -r line; do
+        if [[ "$line" == *"Rolled back to original state."* ]]; then
+            outcome="failure: rollback completed"
+        elif [[ "$line" == *"ERROR:"* || "$line" == *"✗"* ]]; then
+            outcome="failure or warning: inspect timeline"
+        elif [[ "$line" == *"FIX COMPLETE!"* ]]; then
+            outcome="success: fix complete"
+        elif [[ "$line" == *"Dry run complete"* ]]; then
+            outcome="success: dry run"
+        elif [[ "$line" == *"SUCCESS: All checks passed"* ]]; then
+            outcome="success: verification passed"
+        fi
+    done < "$log_file"
+
+    echo "$outcome"
 }
 
 emit_sanitized_diagnostics() {
@@ -662,8 +733,10 @@ collect_diagnostics() {
 
 write_qt_package_bundle_info() {
     local bundle_dir="$1"
+    local raw_file="$bundle_dir/qt-package.raw.txt"
     local info_file="$bundle_dir/qt-package.txt"
     local local_qt_package=""
+    local listing_file required_fw required_plugin required_dylib entry
 
     {
         echo "Qt package status"
@@ -676,21 +749,290 @@ write_qt_package_bundle_info() {
             echo "Availability: unavailable (download script missing)"
         fi
 
-        local_qt_package=$(worms_latest_qt_package_by_version "$REPO_DIR/dist" true || true)
+        local_qt_package=$(worms_latest_qt_package_by_version "$REPO_DIR/dist" false || true)
         if [[ -n "$local_qt_package" ]]; then
             echo "Local package: $(basename "$local_qt_package")"
-            if verify_qt_package_checksum "$local_qt_package"; then
-                echo "Checksum: verified"
+            if [[ -f "${local_qt_package}.sha256" ]]; then
+                if verify_qt_package_checksum "$local_qt_package"; then
+                    echo "Checksum: verified"
+                else
+                    echo "Checksum: mismatch"
+                fi
             else
-                echo "Checksum: mismatch"
+                echo "Checksum: missing"
             fi
             echo ""
             echo "Metadata:"
             tar -xOf "$local_qt_package" METADATA.txt 2>/dev/null || echo "(metadata unavailable)"
+            echo ""
+            echo "Required archive contents"
+            echo "========================="
+
+            listing_file=$(mktemp "${TMPDIR:-/tmp}/wormswmd-qt-listing.XXXXXX")
+            if tar -tzf "$local_qt_package" > "$listing_file" 2>/dev/null; then
+                for required_fw in "${REQUIRED_QT_FRAMEWORKS[@]}"; do
+                    entry="Frameworks/${required_fw}.framework/Versions/5/${required_fw}"
+                    if grep -Fxq "$entry" "$listing_file"; then
+                        echo "PASS framework binary: $entry"
+                    else
+                        echo "FAIL framework binary missing: $entry"
+                    fi
+                done
+
+                for required_plugin in "${REQUIRED_QT_PLUGINS[@]}"; do
+                    entry="PlugIns/$required_plugin"
+                    if grep -Fxq "$entry" "$listing_file"; then
+                        echo "PASS plugin: $entry"
+                    else
+                        echo "FAIL plugin missing: $entry"
+                    fi
+                done
+
+                for required_dylib in "${REQUIRED_BUNDLED_DYLIBS[@]}"; do
+                    entry="Frameworks/$required_dylib"
+                    if grep -Fxq "$entry" "$listing_file"; then
+                        echo "PASS bundled dylib: $entry"
+                    else
+                        echo "FAIL bundled dylib missing: $entry"
+                    fi
+                done
+
+                if grep -Fxq "MANIFEST.txt" "$listing_file"; then
+                    echo "PASS manifest: MANIFEST.txt"
+                else
+                    echo "WARN manifest missing: MANIFEST.txt"
+                fi
+                if grep -Fxq "SOURCE_PROVENANCE.tsv" "$listing_file"; then
+                    echo "PASS source provenance: SOURCE_PROVENANCE.tsv"
+                else
+                    echo "WARN source provenance missing: SOURCE_PROVENANCE.tsv"
+                fi
+            else
+                echo "FAIL unable to list archive contents"
+            fi
+            rm -f "${listing_file:-}"
         else
             echo "Local package: none"
         fi
-    } > "$info_file"
+    } > "$raw_file"
+
+    sanitize_report "$raw_file" "$info_file"
+    rm -f "$raw_file"
+}
+
+write_install_summary() {
+    local bundle_dir="$1"
+    local raw_file="$bundle_dir/install-summary.raw.txt"
+    local summary_file="$bundle_dir/install-summary.txt"
+    local version git_commit git_ref release_line log_file log_name log_mtime log_size outcome logs_list_file
+
+    {
+        echo "Install history summary"
+        echo "======================="
+        echo ""
+
+        version=$(fix_tool_version || true)
+        echo "Fix tool version: ${version:-unknown}"
+        if [[ -d "$REPO_DIR/.git" ]] && command -v git >/dev/null 2>&1; then
+            git_commit=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)
+            git_ref=$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+            echo "Git ref: ${git_ref:-unknown}"
+            echo "Git commit: ${git_commit:-unknown}"
+        elif [[ -f "$REPO_DIR/RELEASE_INFO.txt" ]]; then
+            release_line=$(awk -F': ' '/^Version:/{print $2; exit}' "$REPO_DIR/RELEASE_INFO.txt")
+            echo "Release bundle version: ${release_line:-unknown}"
+        else
+            echo "Source ref: unavailable"
+        fi
+        echo ""
+        echo "Latest installer logs"
+        echo "====================="
+
+        logs_list_file=$(mktemp "${TMPDIR:-/tmp}/wormswmd-fix-logs.XXXXXX")
+        latest_fix_logs > "$logs_list_file"
+
+        if [[ ! -s "$logs_list_file" ]]; then
+            echo "No fix_worms_wmd logs found in ~/Library/Logs/WormsWMD-Fix."
+        else
+            while IFS= read -r log_file; do
+                [[ -n "$log_file" ]] || continue
+                log_name=$(basename "$log_file")
+                log_mtime=$(date -r "$log_file" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "unknown")
+                log_size=$(worms_file_size "$log_file" 2>/dev/null || echo "unknown")
+                outcome=$(infer_log_outcome "$log_file")
+
+                echo ""
+                echo "Log: $log_name"
+                echo "Modified: $log_mtime"
+                echo "Size bytes: $log_size"
+                echo "Inferred outcome: $outcome"
+                echo "Step timeline:"
+                grep -E '^(==>|.*(Log file:|ERROR:|SUCCESS:|Rolled back|Rolling back|Backup created|Backup manifest|All checks passed|Installation verification failed|Copying dependencies failed|AGL stub built successfully|Qt frameworks installed|Dependencies bundled|FIX COMPLETE|Dry run complete|Pre-flight checks|Creating backup|Building AGL|Replacing Qt|Copying dependencies|Fixing library paths|Applying enhancements|Applying finishing touches|Verifying installation))' "$log_file" \
+                    | tail -80 \
+                    | sed 's/[[:cntrl:]]//g' || true
+            done < "$logs_list_file"
+        fi
+        rm -f "$logs_list_file"
+    } > "$raw_file"
+
+    sanitize_report "$raw_file" "$summary_file"
+    rm -f "$raw_file"
+}
+
+write_runtime_invariants() {
+    local bundle_dir="$1"
+    local raw_file="$bundle_dir/runtime-invariants.raw.txt"
+    local summary_file="$bundle_dir/runtime-invariants.txt"
+    local frameworks_dir="$GAME_APP/Contents/Frameworks"
+    local plugins_dir="$GAME_APP/Contents/PlugIns"
+    local agl_path="$frameworks_dir/AGL.framework/Versions/A/AGL"
+    local required_fw required_plugin required_dylib binary archs size rel_path qt_info
+
+    {
+        echo "Required runtime invariant matrix"
+        echo "================================="
+        echo ""
+        echo "Game app: $GAME_APP"
+        echo ""
+
+        if [[ ! -d "$GAME_APP" ]]; then
+            echo "FAIL game app not found"
+        else
+            echo "AGL"
+            echo "---"
+            if [[ -f "$agl_path" ]]; then
+                archs=$(lipo -archs "$agl_path" 2>/dev/null || echo "unknown")
+                size=$(worms_file_size "$agl_path" 2>/dev/null || echo "unknown")
+                if echo "$archs" | tr ' ' '\n' | grep -qx "x86_64"; then
+                    echo "PASS AGL binary: Frameworks/AGL.framework/Versions/A/AGL"
+                else
+                    echo "FAIL AGL binary missing x86_64: $archs"
+                fi
+                echo "AGL archs: $archs"
+                echo "AGL size bytes: $size"
+            else
+                echo "FAIL AGL binary missing: Frameworks/AGL.framework/Versions/A/AGL"
+            fi
+
+            echo ""
+            echo "Qt frameworks"
+            echo "-------------"
+            for required_fw in "${REQUIRED_QT_FRAMEWORKS[@]}"; do
+                binary=$(worms_framework_binary "$frameworks_dir/${required_fw}.framework" "$required_fw" 2>/dev/null || true)
+                if [[ -n "$binary" && -f "$binary" ]]; then
+                    rel_path=${binary#"$GAME_APP/Contents/"}
+                    archs=$(lipo -archs "$binary" 2>/dev/null || echo "unknown")
+                    if echo "$archs" | tr ' ' '\n' | grep -qx "x86_64"; then
+                        echo "PASS $required_fw: $rel_path ($archs)"
+                    else
+                        echo "FAIL $required_fw missing x86_64: $rel_path ($archs)"
+                    fi
+                else
+                    echo "FAIL $required_fw binary missing"
+                fi
+            done
+            if [[ -f "$frameworks_dir/QtCore.framework/Versions/5/QtCore" ]]; then
+                qt_info=$(otool -L "$frameworks_dir/QtCore.framework/Versions/5/QtCore" 2>/dev/null | sed -n '2p' || true)
+                echo "QtCore install name: ${qt_info:-unknown}"
+            fi
+
+            echo ""
+            echo "Qt plugins"
+            echo "----------"
+            for required_plugin in "${REQUIRED_QT_PLUGINS[@]}"; do
+                if [[ -f "$plugins_dir/$required_plugin" ]]; then
+                    archs=$(lipo -archs "$plugins_dir/$required_plugin" 2>/dev/null || echo "unknown")
+                    if echo "$archs" | tr ' ' '\n' | grep -qx "x86_64"; then
+                        echo "PASS plugin: PlugIns/$required_plugin ($archs)"
+                    else
+                        echo "FAIL plugin missing x86_64: PlugIns/$required_plugin ($archs)"
+                    fi
+                else
+                    echo "FAIL plugin missing: PlugIns/$required_plugin"
+                fi
+            done
+
+            echo ""
+            echo "Bundled dependency dylibs"
+            echo "------------------------"
+            for required_dylib in "${REQUIRED_BUNDLED_DYLIBS[@]}"; do
+                if [[ -f "$frameworks_dir/$required_dylib" ]]; then
+                    archs=$(lipo -archs "$frameworks_dir/$required_dylib" 2>/dev/null || echo "unknown")
+                    if echo "$archs" | tr ' ' '\n' | grep -qx "x86_64"; then
+                        echo "PASS dylib: Frameworks/$required_dylib ($archs)"
+                    else
+                        echo "FAIL dylib missing x86_64: Frameworks/$required_dylib ($archs)"
+                    fi
+                else
+                    echo "FAIL dylib missing: Frameworks/$required_dylib"
+                fi
+            done
+        fi
+    } > "$raw_file"
+
+    sanitize_report "$raw_file" "$summary_file"
+    rm -f "$raw_file"
+}
+
+write_backup_summary() {
+    local bundle_dir="$1"
+    local raw_file="$bundle_dir/backup-summary.raw.txt"
+    local summary_file="$bundle_dir/backup-summary.txt"
+    local backup_count=0 backup manifest mtime symlink_status manifest_status
+
+    {
+        echo "Backup integrity summary"
+        echo "========================"
+        echo ""
+
+        if [[ ! -d "$HOME/Documents" ]]; then
+            echo "Documents directory not found."
+        else
+            backup_count=$(find "$HOME/Documents" -mindepth 1 -maxdepth 1 -type d -name "WormsWMD-Backup-*" -print 2>/dev/null | wc -l | tr -d ' ')
+            echo "Backup count: $backup_count"
+
+            find "$HOME/Documents" -mindepth 1 -maxdepth 1 -type d -name "WormsWMD-Backup-*" -print0 2>/dev/null \
+                | while IFS= read -r -d '' backup; do
+                    mtime=$(stat -f "%m" "$backup" 2>/dev/null || echo 0)
+                    printf '%s\t%s\n' "$mtime" "$backup"
+                done \
+                | sort -nr \
+                | awk -F '\t' 'NR <= 5 { sub(/^[^\t]*\t/, ""); print }' \
+                | while IFS= read -r backup; do
+                    [[ -n "$backup" ]] || continue
+                    manifest="$backup/BACKUP_MANIFEST.tsv"
+                    mtime=$(date -r "$backup" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "unknown")
+                    if worms_validate_tree_symlinks "$backup" >/dev/null 2>&1; then
+                        symlink_status="PASS"
+                    else
+                        symlink_status="FAIL"
+                    fi
+                    if [[ -f "$manifest" ]]; then
+                        if worms_verify_manifest "$backup" "$manifest" >/dev/null 2>&1; then
+                            manifest_status="PASS"
+                        else
+                            manifest_status="FAIL"
+                        fi
+                    else
+                        manifest_status="WARN missing"
+                    fi
+
+                    echo ""
+                    echo "Backup: $(basename "$backup")"
+                    echo "Modified: $mtime"
+                    echo "Symlink validation: $symlink_status"
+                    echo "Manifest validation: $manifest_status"
+                    if [[ -d "$backup/Frameworks/AGL.framework" ]]; then
+                        echo "Looks already fixed: yes (AGL.framework present)"
+                    else
+                        echo "Looks already fixed: unknown/no AGL.framework"
+                    fi
+                done
+        fi
+    } > "$raw_file"
+
+    sanitize_report "$raw_file" "$summary_file"
+    rm -f "$raw_file"
 }
 
 copy_backup_manifests() {
@@ -704,8 +1046,8 @@ copy_backup_manifests() {
         while IFS= read -r -d '' backup; do
             manifest="$backup/BACKUP_MANIFEST.tsv"
             if [[ -f "$manifest" ]]; then
-                target_name="$(basename "$backup").tsv"
-                cp "$manifest" "$manifests_dir/$target_name"
+                target_name=$(printf 'backup-manifest-%02d.tsv' "$((copied + 1))")
+                sanitize_report "$manifest" "$manifests_dir/$target_name"
                 copied=$((copied + 1))
             fi
         done < <(find "$HOME/Documents" -mindepth 1 -maxdepth 1 -type d -name "WormsWMD-Backup-*" -print0 2>/dev/null)
@@ -730,7 +1072,7 @@ collect_support_bundle() {
         echo "Generated: $(date '+%Y-%m-%d %H:%M:%S %Z')"
         echo "Repository: https://github.com/cboyd0319/WormsWMD-macOS-Fix"
         echo ""
-        echo "This bundle contains sanitized diagnostics, Qt package status, and backup manifests."
+        echo "This bundle contains sanitized diagnostics, install history, runtime invariant status, Qt package status, and backup manifests."
         echo "It does not include save files, game binaries, or raw crash logs."
     } > "$BUNDLE_TEMP_DIR/README.txt"
 
@@ -743,6 +1085,9 @@ collect_support_bundle() {
     rm -f "$raw_report"
 
     write_qt_package_bundle_info "$BUNDLE_TEMP_DIR"
+    write_install_summary "$BUNDLE_TEMP_DIR"
+    write_runtime_invariants "$BUNDLE_TEMP_DIR"
+    write_backup_summary "$BUNDLE_TEMP_DIR"
     copy_backup_manifests "$BUNDLE_TEMP_DIR"
 
     COPYFILE_DISABLE=1 tar \

--- a/tools/collect_diagnostics.sh
+++ b/tools/collect_diagnostics.sh
@@ -348,7 +348,9 @@ collect_diagnostics() {
             local agl_archs agl_size
             agl_archs=$(lipo -archs "$agl_path" 2>/dev/null || echo "unknown")
             agl_size=$(stat -f%z "$agl_path" 2>/dev/null || echo "0")
-            if [[ "$agl_size" -lt 100000 ]]; then
+            if ! echo "$agl_archs" | tr ' ' '\n' | grep -qx "x86_64"; then
+                fail "AGL stub missing x86_64 architecture (archs: $agl_archs)"
+            elif [[ "$agl_size" -lt 100000 ]]; then
                 ok "AGL stub installed (archs: $agl_archs, size: ${agl_size} bytes)"
             else
                 warn "AGL framework present but may not be stub (size: ${agl_size} bytes)"
@@ -382,14 +384,26 @@ collect_diagnostics() {
         if [[ -d "$GAME_APP/Contents/Frameworks/QtDBus.framework" ]]; then
             ok "QtDBus.framework present"
         else
-            warn "QtDBus.framework missing"
+            fail "QtDBus.framework missing"
         fi
 
         # Check QtSvg
         if [[ -d "$GAME_APP/Contents/Frameworks/QtSvg.framework" ]]; then
             ok "QtSvg.framework present"
         else
-            warn "QtSvg.framework missing"
+            fail "QtSvg.framework missing"
+        fi
+
+        if [[ -f "$GAME_APP/Contents/PlugIns/platforms/libqcocoa.dylib" ]]; then
+            ok "Qt platform plugin present"
+        else
+            fail "Qt platform plugin missing"
+        fi
+
+        if [[ -f "$GAME_APP/Contents/PlugIns/imageformats/libqsvg.dylib" ]]; then
+            ok "Qt SVG image plugin present"
+        else
+            fail "Qt SVG image plugin missing"
         fi
     else
         fail "Frameworks directory not found"

--- a/tools/preflight_check.sh
+++ b/tools/preflight_check.sh
@@ -250,14 +250,20 @@ check_info "Bundle size: $bundle_size"
 section "Fix Status"
 
 FRAMEWORKS_DIR="$GAME_APP/Contents/Frameworks"
+PLUGINS_DIR="$GAME_APP/Contents/PlugIns"
 
 # Check AGL stub
-if [[ -d "$FRAMEWORKS_DIR/AGL.framework" ]]; then
-    agl_arch=$(binary_archs "$FRAMEWORKS_DIR/AGL.framework/Versions/A/AGL")
-    check_pass "AGL stub installed (arch: $agl_arch)"
+agl_stub="$FRAMEWORKS_DIR/AGL.framework/Versions/A/AGL"
+if [[ -f "$agl_stub" ]]; then
+    agl_arch=$(binary_archs "$agl_stub")
+    if echo "$agl_arch" | tr ' ' '\n' | grep -qx "x86_64"; then
+        check_pass "AGL stub installed (arch: $agl_arch)"
+    else
+        check_fail "AGL stub does not include x86_64 architecture (arch: $agl_arch)"
+    fi
 else
     if [[ "$macos_major" =~ ^[0-9]+$ ]] && [[ "$macos_major" -ge 26 ]]; then
-        check_fail "AGL stub NOT installed - game will not launch on macOS 26+"
+        check_fail "AGL stub binary NOT installed - game will not launch on macOS 26+"
     else
         check_info "AGL stub not installed (may not be needed)"
     fi
@@ -289,6 +295,14 @@ else
     check_fail "QtCore framework not found"
 fi
 
+for required_fw in QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg; do
+    if [[ -d "$FRAMEWORKS_DIR/$required_fw.framework" ]]; then
+        check_pass "$required_fw.framework present"
+    else
+        check_fail "$required_fw.framework not found"
+    fi
+done
+
 # Check for AGL dependencies in Qt
 if [[ -f "$FRAMEWORKS_DIR/QtGui.framework/Versions/5/QtGui" ]]; then
     if $HAVE_OTOOL; then
@@ -302,6 +316,18 @@ if [[ -f "$FRAMEWORKS_DIR/QtGui.framework/Versions/5/QtGui" ]]; then
     fi
 else
     check_warn "QtGui framework not found"
+fi
+
+if [[ -f "$PLUGINS_DIR/platforms/libqcocoa.dylib" ]]; then
+    check_pass "Qt platform plugin present"
+else
+    check_fail "Qt platform plugin not found"
+fi
+
+if [[ -f "$PLUGINS_DIR/imageformats/libqsvg.dylib" ]]; then
+    check_pass "Qt SVG image plugin present"
+else
+    check_fail "Qt SVG image plugin not found"
 fi
 
 # Check code signing

--- a/tools/test_backup_saves_regression.sh
+++ b/tools/test_backup_saves_regression.sh
@@ -52,4 +52,22 @@ for expected in \
     fi
 done
 
+printf 'corrupt team17\n' > "$team17_dir/visible-team17"
+printf 'stale team17\n' > "$team17_dir/stale-team17"
+printf 'corrupt steam\n' > "$steam_dir/visible-steam"
+printf 'stale steam\n' > "$steam_dir/stale-steam"
+
+HOME="$test_home" BACKUP_DIR="$backup_dir" WORMSWMD_RESTORE_ASSUME_YES=1 \
+    "$ROOT_DIR/tools/backup_saves.sh" --restore "$archive" >/dev/null \
+    || fail "save restore failed"
+
+grep -Fxq 'team17 visible' "$team17_dir/visible-team17" \
+    || fail "Team17 save file was not restored from backup"
+grep -Fxq 'steam visible' "$steam_dir/visible-steam" \
+    || fail "Steam save file was not restored from backup"
+[[ ! -e "$team17_dir/stale-team17" ]] \
+    || fail "Team17 restore left a file that was absent from the backup"
+[[ ! -e "$steam_dir/stale-steam" ]] \
+    || fail "Steam restore left a file that was absent from the backup"
+
 printf 'Save backup regression check passed.\n'

--- a/tools/test_installer_rollback_regression.sh
+++ b/tools/test_installer_rollback_regression.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# Regression check for top-level installer rollback after post-backup failures.
+#
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+fail() {
+    printf 'installer rollback regression check failed: %s\n' "$*" >&2
+    exit 1
+}
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/wormswmd-installer-rollback.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT
+
+test_home="$tmp_dir/home"
+fake_bin="$tmp_dir/bin"
+game_app="$test_home/Library/Application Support/Steam/steamapps/common/WormsWMD/Worms W.M.D.app"
+
+mkdir -p \
+    "$fake_bin" \
+    "$game_app/Contents/MacOS" \
+    "$game_app/Contents/Frameworks" \
+    "$game_app/Contents/PlugIns/platforms" \
+    "$game_app/Contents/PlugIns/imageformats" \
+    "$game_app/Contents/Resources/DataOSX" \
+    "$game_app/Contents/Resources/CommonData"
+
+printf '#!/bin/bash\nexit 0\n' > "$game_app/Contents/MacOS/Worms W.M.D"
+chmod +x "$game_app/Contents/MacOS/Worms W.M.D"
+printf 'original framework\n' > "$game_app/Contents/Frameworks/original-framework.txt"
+printf 'original platform plugin\n' > "$game_app/Contents/PlugIns/platforms/original-platform.dylib"
+printf 'original image plugin\n' > "$game_app/Contents/PlugIns/imageformats/original-image.dylib"
+printf '<plist version="1.0"><dict></dict></plist>\n' > "$game_app/Contents/Info.plist"
+printf 'URL_Internal = "http://xom.team17.com"\n' > "$game_app/Contents/Resources/DataOSX/SteamConfig.txt"
+printf 'MainUrl = "http://www.google-analytics.com"\n' > "$game_app/Contents/Resources/CommonData/AnalyticsConfig.txt"
+
+cat > "$fake_bin/sw_vers" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    -productName) printf '%s\n' "macOS" ;;
+    -productVersion) printf '%s\n' "26.0.1" ;;
+    -buildVersion) printf '%s\n' "99A999" ;;
+    *) exit 1 ;;
+esac
+STUB
+
+cat > "$fake_bin/uname" <<'STUB'
+#!/bin/bash
+printf '%s\n' "x86_64"
+STUB
+
+cat > "$fake_bin/arch" <<'STUB'
+#!/bin/bash
+if [[ "${1:-}" == "-x86_64" ]]; then
+    shift
+fi
+exec "$@"
+STUB
+
+cat > "$fake_bin/clang" <<'STUB'
+#!/bin/bash
+out=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o)
+            out="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+[[ -n "$out" ]] || exit 1
+mkdir -p "$(dirname "$out")"
+printf 'fake macho\n' > "$out"
+exit 0
+STUB
+
+cat > "$fake_bin/lipo" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    -create)
+        out=""
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == "-output" ]]; then
+                out="${2:-}"
+                break
+            fi
+            shift
+        done
+        [[ -n "$out" ]] || exit 1
+        printf 'fake universal macho\n' > "$out"
+        ;;
+    -archs)
+        printf '%s\n' "x86_64"
+        ;;
+    -info)
+        printf '%s\n' "Architectures in the fat file: ${2:-binary} are: x86_64 arm64"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+STUB
+
+cat > "$fake_bin/file" <<'STUB'
+#!/bin/bash
+printf '%s: Mach-O universal binary with 2 architectures\n' "${1:-binary}"
+STUB
+
+cat > "$fake_bin/otool" <<'STUB'
+#!/bin/bash
+if [[ "${1:-}" == "-L" ]]; then
+    printf '%s:\n' "${2:-binary}"
+    printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n'
+    exit 0
+fi
+exit 1
+STUB
+
+cat > "$fake_bin/install_name_tool" <<'STUB'
+#!/bin/bash
+printf '%s\n' "forced install_name_tool failure" >&2
+exit 1
+STUB
+
+cat > "$fake_bin/codesign" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+cat > "$fake_bin/xattr" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+chmod +x "$fake_bin"/*
+
+set +e
+output=$(
+    HOME="$test_home" \
+        PATH="$fake_bin:$PATH" \
+        GAME_APP="$game_app" \
+        "$ROOT_DIR/fix_worms_wmd.sh" --force 2>&1
+)
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+    fail "installer succeeded even though install_name_tool was forced to fail"
+fi
+
+grep -Fq "Rolled back to original state." <<< "$output" \
+    || fail "installer failure did not report successful rollback: $output"
+
+grep -Fxq 'original framework' "$game_app/Contents/Frameworks/original-framework.txt" \
+    || fail "original Frameworks contents were not restored"
+grep -Fxq 'original platform plugin' "$game_app/Contents/PlugIns/platforms/original-platform.dylib" \
+    || fail "original platform plugin contents were not restored"
+grep -Fxq 'original image plugin' "$game_app/Contents/PlugIns/imageformats/original-image.dylib" \
+    || fail "original image plugin contents were not restored"
+
+[[ ! -e "$game_app/Contents/Frameworks/QtCore.framework" ]] \
+    || fail "partial QtCore.framework remained after rollback"
+[[ ! -e "$game_app/Contents/Frameworks/AGL.framework" ]] \
+    || fail "partial AGL.framework remained after rollback"
+[[ ! -e "$game_app/Contents/PlugIns/platforms/libqcocoa.dylib" ]] \
+    || fail "partial platform plugin remained after rollback"
+
+backup_count=$(find "$test_home/Documents" -mindepth 1 -maxdepth 1 -type d -name 'WormsWMD-Backup-*' -print 2>/dev/null | wc -l | tr -d ' ')
+[[ "$backup_count" == "1" ]] || fail "expected one preserved rollback backup, found $backup_count"
+
+printf 'Installer rollback regression check passed.\n'

--- a/tools/test_issue_10_regression.sh
+++ b/tools/test_issue_10_regression.sh
@@ -9,6 +9,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
 # shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/common.sh"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/logging.sh"
 
 fail() {
     printf 'issue #10 regression check failed: %s\n' "$*" >&2
@@ -97,5 +99,18 @@ unique_backup=$(worms_unique_path "$tmp_dir/backup")
 if [[ "$unique_backup" != "$tmp_dir/backup-1" ]]; then
     fail "unique directory path did not add a numeric suffix"
 fi
+
+(
+    HOME="$tmp_dir/home"
+    LOG_DIR=""
+    LOG_FILE=""
+    worms_prepare_log_file "fix_worms_wmd"
+    first_log="$LOG_FILE"
+    touch "$first_log"
+    LOG_FILE=""
+    worms_prepare_log_file "fix_worms_wmd"
+    second_log="$LOG_FILE"
+    [[ "$first_log" != "$second_log" ]]
+) || fail "default log path generation can reuse an existing log path"
 
 printf 'Issue #10 regression check passed.\n'

--- a/tools/test_issue_12_agl_install_failure.sh
+++ b/tools/test_issue_12_agl_install_failure.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+#
+# Regression check for issue #12 missing AGL stub partial installs.
+#
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+fail() {
+    printf 'issue #12 AGL install failure check failed: %s\n' "$*" >&2
+    exit 1
+}
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/wormswmd-issue12.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT
+
+agl_build_dir="$tmp_dir/agl-build"
+if grep -Fq 'arch -x86_64 clang' "$ROOT_DIR/scripts/01_build_agl_stub.sh"; then
+    fail "AGL build script still runs clang under Rosetta instead of using native cross-compilation"
+fi
+BUILD_DIR="$agl_build_dir" "$ROOT_DIR/scripts/01_build_agl_stub.sh" >/dev/null \
+    || fail "AGL build script failed to build the universal stub"
+agl_archs=$(lipo -archs "$agl_build_dir/AGL" 2>/dev/null || true)
+echo "$agl_archs" | tr ' ' '\n' | grep -qx "x86_64" \
+    || fail "AGL build output is missing x86_64 architecture: ${agl_archs:-unknown}"
+
+make_game_app() {
+    local game_app="$1"
+
+    mkdir -p "$game_app/Contents/MacOS"
+    printf '#!/bin/bash\nexit 0\n' > "$game_app/Contents/MacOS/Worms W.M.D"
+    chmod +x "$game_app/Contents/MacOS/Worms W.M.D"
+}
+
+make_qt_framework_sources() {
+    local qt_prefix="$1"
+    local fw
+
+    shift
+    mkdir -p "$qt_prefix/lib" "$qt_prefix/plugins/platforms" "$qt_prefix/plugins/imageformats"
+    for fw in "$@"; do
+        mkdir -p "$qt_prefix/lib/$fw.framework/Versions/5"
+        touch "$qt_prefix/lib/$fw.framework/Versions/5/$fw"
+    done
+}
+
+make_installed_frameworks() {
+    local game_app="$1"
+    local fw
+
+    for fw in QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg; do
+        mkdir -p "$game_app/Contents/Frameworks/$fw.framework/Versions/5"
+        touch "$game_app/Contents/Frameworks/$fw.framework/Versions/5/$fw"
+    done
+    mkdir -p "$game_app/Contents/Frameworks/AGL.framework/Versions/A"
+    touch "$game_app/Contents/Frameworks/AGL.framework/Versions/A/AGL"
+}
+
+write_verify_stubs() {
+    local bin_dir="$1"
+
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/lipo" <<'STUB'
+#!/bin/bash
+if [[ "${1:-}" == "-archs" ]]; then
+    if [[ "${2:-}" == *"AGL.framework"* ]]; then
+        printf '%s\n' "${WORMS_TEST_AGL_ARCHS:-x86_64}"
+    else
+        printf '%s\n' "x86_64"
+    fi
+    exit 0
+fi
+exit 1
+STUB
+    cat > "$bin_dir/otool" <<'STUB'
+#!/bin/bash
+if [[ "${1:-}" == "-L" ]]; then
+    printf '%s:\n' "${2:-binary}"
+    printf '\t@rpath/QtCore.framework/Versions/5/QtCore (compatibility version 5.15.0, current version 5.15.19)\n'
+    printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n'
+    exit 0
+fi
+exit 1
+STUB
+    cat > "$bin_dir/sw_vers" <<'STUB'
+#!/bin/bash
+case "${1:-}" in
+    -productName) printf '%s\n' "macOS" ;;
+    -productVersion) printf '%s\n' "26.0.1" ;;
+    *) exit 1 ;;
+esac
+STUB
+    cat > "$bin_dir/uname" <<'STUB'
+#!/bin/bash
+printf '%s\n' "x86_64"
+STUB
+    cat > "$bin_dir/codesign" <<'STUB'
+#!/bin/bash
+printf '%s\n' "adhoc" >&2
+exit 0
+STUB
+    cat > "$bin_dir/xattr" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+    chmod +x "$bin_dir/lipo" "$bin_dir/otool" "$bin_dir/sw_vers" "$bin_dir/uname" "$bin_dir/codesign" "$bin_dir/xattr"
+}
+
+game_app="$tmp_dir/missing-agl/Worms W.M.D.app"
+build_dir="$tmp_dir/empty-build"
+make_game_app "$game_app"
+mkdir -p "$build_dir"
+
+set +e
+output=$(
+    GAME_APP="$game_app" \
+        BUILD_DIR="$build_dir" \
+        "$ROOT_DIR/scripts/04_fix_library_paths.sh" 2>&1
+)
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+    fail "library path fixer succeeded without a built AGL stub"
+fi
+
+if ! grep -Fq "ERROR: AGL stub not found at $build_dir/AGL" <<< "$output"; then
+    fail "missing AGL stub did not produce the expected hard error: $output"
+fi
+
+if grep -Fq "Library path fixes complete." <<< "$output"; then
+    fail "library path fixer continued after the missing AGL stub error"
+fi
+
+if [[ -e "$game_app/Contents/Frameworks/AGL.framework" ]]; then
+    fail "library path fixer created an AGL framework without a built stub"
+fi
+
+stale_agl_game_app="$tmp_dir/stale-agl-links/Worms W.M.D.app"
+stale_bin_dir="$tmp_dir/stale-agl-bin"
+make_game_app "$stale_agl_game_app"
+mkdir -p \
+    "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/A/Resources" \
+    "$stale_agl_game_app/Contents/PlugIns/platforms" \
+    "$stale_agl_game_app/Contents/PlugIns/imageformats" \
+    "$stale_bin_dir"
+ln -s A "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/Current"
+ln -s Versions/Current/AGL "$stale_agl_game_app/Contents/Frameworks/AGL.framework/AGL"
+ln -s Versions/Current/Resources "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Resources"
+ln -s A "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/A/A"
+ln -s Versions/Current/Resources "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/A/Resources/Resources"
+cat > "$stale_bin_dir/install_name_tool" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+cat > "$stale_bin_dir/otool" <<'STUB'
+#!/bin/bash
+if [[ "${1:-}" == "-L" ]]; then
+    printf '%s:\n' "${2:-binary}"
+    printf '\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1.0.0)\n'
+    exit 0
+fi
+exit 1
+STUB
+chmod +x "$stale_bin_dir/install_name_tool" "$stale_bin_dir/otool"
+
+PATH="$stale_bin_dir:$PATH" \
+    GAME_APP="$stale_agl_game_app" \
+    BUILD_DIR="$agl_build_dir" \
+    "$ROOT_DIR/scripts/04_fix_library_paths.sh" >/dev/null \
+    || fail "library path fixer failed when replacing stale AGL framework symlinks"
+[[ ! -L "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/A/A" ]] \
+    || fail "library path fixer left a nested Versions/A/A symlink after repeated AGL install"
+[[ ! -L "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/A/Resources/Resources" ]] \
+    || fail "library path fixer left a nested Resources/Resources symlink after repeated AGL install"
+[[ -L "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Versions/Current" ]] \
+    || fail "library path fixer did not recreate Versions/Current as a symlink"
+[[ -L "$stale_agl_game_app/Contents/Frameworks/AGL.framework/Resources" ]] \
+    || fail "library path fixer did not recreate top-level Resources as a symlink"
+
+qt_game_app="$tmp_dir/missing-qt/Worms W.M.D.app"
+qt_prefix="$tmp_dir/qt-prefix"
+make_game_app "$qt_game_app"
+make_qt_framework_sources "$qt_prefix" QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus
+touch "$qt_prefix/plugins/platforms/libqcocoa.dylib"
+touch "$qt_prefix/plugins/imageformats/libqgif.dylib"
+
+set +e
+qt_output=$(
+    GAME_APP="$qt_game_app" \
+        QT_SOURCE=homebrew \
+        QT_PREFIX="$qt_prefix" \
+        WORMSWMD_ALLOW_CUSTOM_QT_PREFIX=1 \
+        "$ROOT_DIR/scripts/02_replace_qt_frameworks.sh" 2>&1
+)
+qt_status=$?
+set -e
+
+if [[ "$qt_status" -eq 0 ]]; then
+    fail "Qt replacement succeeded without required QtSvg.framework source"
+fi
+
+if ! grep -Fq "ERROR: Required Qt framework missing from source: $qt_prefix/lib/QtSvg.framework" <<< "$qt_output"; then
+    fail "missing required Qt framework did not produce the expected hard error: $qt_output"
+fi
+
+if grep -Fq "Qt frameworks replaced successfully." <<< "$qt_output"; then
+    fail "Qt replacement continued after the missing required framework error"
+fi
+
+plugin_game_app="$tmp_dir/missing-platform-plugin/Worms W.M.D.app"
+plugin_prefix="$tmp_dir/qt-missing-platform-plugin"
+make_game_app "$plugin_game_app"
+make_qt_framework_sources "$plugin_prefix" QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg
+mkdir -p "$plugin_game_app/Contents/PlugIns/platforms" "$plugin_game_app/Contents/PlugIns/imageformats"
+touch "$plugin_game_app/Contents/PlugIns/platforms/original-platform.dylib"
+touch "$plugin_game_app/Contents/PlugIns/imageformats/original-image.dylib"
+touch "$plugin_prefix/plugins/imageformats/libqsvg.dylib"
+
+set +e
+plugin_output=$(
+    GAME_APP="$plugin_game_app" \
+        QT_SOURCE=homebrew \
+        QT_PREFIX="$plugin_prefix" \
+        WORMSWMD_ALLOW_CUSTOM_QT_PREFIX=1 \
+        "$ROOT_DIR/scripts/02_replace_qt_frameworks.sh" 2>&1
+)
+plugin_status=$?
+set -e
+
+if [[ "$plugin_status" -eq 0 ]]; then
+    fail "Qt replacement succeeded without required libqcocoa.dylib source"
+fi
+if ! grep -Fq "ERROR: Required Qt platform plugin missing from source: $plugin_prefix/plugins/platforms/libqcocoa.dylib" <<< "$plugin_output"; then
+    fail "missing platform plugin did not produce the expected hard error: $plugin_output"
+fi
+[[ -f "$plugin_game_app/Contents/PlugIns/platforms/original-platform.dylib" ]] \
+    || fail "platform plugin preflight deleted existing plugins before failing"
+[[ -f "$plugin_game_app/Contents/PlugIns/imageformats/original-image.dylib" ]] \
+    || fail "platform plugin preflight deleted existing image plugins before failing"
+
+image_plugin_game_app="$tmp_dir/missing-image-plugin/Worms W.M.D.app"
+image_plugin_prefix="$tmp_dir/qt-missing-image-plugin"
+make_game_app "$image_plugin_game_app"
+make_qt_framework_sources "$image_plugin_prefix" QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg
+mkdir -p "$image_plugin_game_app/Contents/PlugIns/platforms" "$image_plugin_game_app/Contents/PlugIns/imageformats"
+touch "$image_plugin_game_app/Contents/PlugIns/platforms/original-platform.dylib"
+touch "$image_plugin_game_app/Contents/PlugIns/imageformats/original-image.dylib"
+touch "$image_plugin_prefix/plugins/platforms/libqcocoa.dylib"
+touch "$image_plugin_prefix/plugins/imageformats/libqgif.dylib"
+
+set +e
+image_plugin_output=$(
+    GAME_APP="$image_plugin_game_app" \
+        QT_SOURCE=homebrew \
+        QT_PREFIX="$image_plugin_prefix" \
+        WORMSWMD_ALLOW_CUSTOM_QT_PREFIX=1 \
+        "$ROOT_DIR/scripts/02_replace_qt_frameworks.sh" 2>&1
+)
+image_plugin_status=$?
+set -e
+
+if [[ "$image_plugin_status" -eq 0 ]]; then
+    fail "Qt replacement succeeded without required libqsvg.dylib source"
+fi
+if ! grep -Fq "ERROR: Required Qt image plugin missing from source: $image_plugin_prefix/plugins/imageformats/libqsvg.dylib" <<< "$image_plugin_output"; then
+    fail "missing image plugin did not produce the expected hard error: $image_plugin_output"
+fi
+[[ -f "$image_plugin_game_app/Contents/PlugIns/platforms/original-platform.dylib" ]] \
+    || fail "image plugin preflight deleted existing platform plugins before failing"
+[[ -f "$image_plugin_game_app/Contents/PlugIns/imageformats/original-image.dylib" ]] \
+    || fail "image plugin preflight deleted existing image plugins before failing"
+
+verify_bin="$tmp_dir/verify-bin"
+write_verify_stubs "$verify_bin"
+verify_game_app="$tmp_dir/verify-missing-plugins/Worms W.M.D.app"
+make_game_app "$verify_game_app"
+make_installed_frameworks "$verify_game_app"
+
+set +e
+verify_output=$(
+    PATH="$verify_bin:$PATH" \
+        GAME_APP="$verify_game_app" \
+        "$ROOT_DIR/scripts/05_verify_installation.sh" 2>&1
+)
+verify_status=$?
+set -e
+
+if [[ "$verify_status" -eq 0 ]]; then
+    fail "installation verifier succeeded without required Qt plugins"
+fi
+grep -Fq "ERROR: Required platform plugin missing: platforms/libqcocoa.dylib" <<< "$verify_output" \
+    || fail "verifier did not report missing platform plugin: $verify_output"
+grep -Fq "ERROR: Required image plugin missing: imageformats/libqsvg.dylib" <<< "$verify_output" \
+    || fail "verifier did not report missing image plugin: $verify_output"
+
+agl_arch_game_app="$tmp_dir/verify-agl-arch/Worms W.M.D.app"
+make_game_app "$agl_arch_game_app"
+make_installed_frameworks "$agl_arch_game_app"
+mkdir -p "$agl_arch_game_app/Contents/PlugIns/platforms" "$agl_arch_game_app/Contents/PlugIns/imageformats"
+touch "$agl_arch_game_app/Contents/PlugIns/platforms/libqcocoa.dylib"
+touch "$agl_arch_game_app/Contents/PlugIns/imageformats/libqsvg.dylib"
+
+set +e
+agl_arch_output=$(
+    PATH="$verify_bin:$PATH" \
+        WORMS_TEST_AGL_ARCHS=arm64 \
+        GAME_APP="$agl_arch_game_app" \
+        "$ROOT_DIR/scripts/05_verify_installation.sh" 2>&1
+)
+agl_arch_status=$?
+set -e
+
+if [[ "$agl_arch_status" -eq 0 ]]; then
+    fail "installation verifier succeeded with an AGL stub missing x86_64"
+fi
+grep -Fq "ERROR: AGL stub architecture is arm64 (expected x86_64 or universal)" <<< "$agl_arch_output" \
+    || fail "verifier did not report non-x86_64 AGL architecture: $agl_arch_output"
+
+deps_game_app="$tmp_dir/missing-prebuilt-deps/Worms W.M.D.app"
+make_game_app "$deps_game_app"
+mkdir -p "$deps_game_app/Contents/Frameworks"
+touch "$deps_game_app/Contents/Frameworks/libglib-2.0.0.dylib"
+
+set +e
+deps_output=$(
+    GAME_APP="$deps_game_app" \
+        QT_SOURCE=prebuild \
+        "$ROOT_DIR/scripts/03_copy_dependencies.sh" 2>&1
+)
+deps_status=$?
+set -e
+
+if [[ "$deps_status" -eq 0 ]]; then
+    fail "prebuilt dependency verification succeeded with only one bundled dylib"
+fi
+grep -Fq "ERROR: Required bundled dependency missing: libpcre2-16.0.dylib" <<< "$deps_output" \
+    || fail "missing prebuilt dependency did not produce the expected hard error: $deps_output"
+
+printf 'Issue #12 AGL install failure check passed.\n'

--- a/tools/test_launcher_friction.sh
+++ b/tools/test_launcher_friction.sh
@@ -46,11 +46,48 @@ grep -Fq "| \`7\` | Launch Worms W.M.D. |" "$readme" \
     || fail "README.md launcher options table is missing option 7"
 grep -Fq 'option 7 to launch Worms W.M.D' "$install_doc" \
     || fail "docs/INSTALL.md launcher option list is missing option 7"
+grep -Fq "GAME_APP=\"\$GAME_APP\" ./fix_worms_wmd.sh --force" "$ROOT_DIR/tools/watch_for_updates.sh" \
+    || fail "watcher daemon reapply does not forward GAME_APP"
+if ! grep -F "GAME_APP=\"\$GAME_APP\" ./fix_worms_wmd.sh" "$ROOT_DIR/tools/watch_for_updates.sh" | grep -Fvq -- "--force"; then
+    fail "watcher interactive reapply does not forward GAME_APP"
+fi
 
 grep -Fq 'macOS 26+ Fix Installer' "$ROOT_DIR/install.sh" \
     || fail "install.sh banner still uses stale macOS version wording"
 grep -Fq 'macOS 26+ and macOS 27 Golden Gate' "$ROOT_DIR/Install Fix.command" \
     || fail "Install Fix.command banner does not mention macOS 27 Golden Gate"
+
+watch_home="$tmp_dir/watch-home"
+watch_bin="$tmp_dir/watch-bin"
+watch_log="$tmp_dir/launchctl.log"
+custom_game_app="$tmp_dir/Custom & Path/Worms W.M.D.app"
+mkdir -p "$watch_home" "$watch_bin" "$custom_game_app/Contents/MacOS"
+: > "$custom_game_app/Contents/MacOS/Worms W.M.D"
+chmod +x "$custom_game_app/Contents/MacOS/Worms W.M.D"
+cat > "$watch_bin/launchctl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "$WORMS_TEST_LAUNCHCTL_LOG"
+exit 0
+STUB
+chmod +x "$watch_bin/launchctl"
+
+HOME="$watch_home" \
+    GAME_APP="$custom_game_app" \
+    WORMS_TEST_LAUNCHCTL_LOG="$watch_log" \
+    PATH="$watch_bin:$PATH" \
+    "$ROOT_DIR/tools/watch_for_updates.sh" --install >/dev/null \
+    || fail "watcher install failed with a custom GAME_APP"
+
+watch_plist="$watch_home/Library/LaunchAgents/com.wormswmd.fix.watcher.plist"
+[[ -f "$watch_plist" ]] || fail "watcher install did not create a LaunchAgent plist"
+grep -Fq '<key>EnvironmentVariables</key>' "$watch_plist" \
+    || fail "watcher LaunchAgent does not persist environment variables"
+grep -Fq '<key>GAME_APP</key>' "$watch_plist" \
+    || fail "watcher LaunchAgent does not persist GAME_APP"
+grep -Fq '<string>'"$tmp_dir"'/Custom &amp; Path/Worms W.M.D.app</string>' "$watch_plist" \
+    || fail "watcher LaunchAgent does not XML-escape and persist the custom GAME_APP"
+grep -Fq "bootstrap gui/" "$watch_log" \
+    || fail "watcher install did not attempt to bootstrap the LaunchAgent"
 
 printf 'q\n' | bash "$launcher" > "$tmp_dir/menu.out" 2>&1 \
     || fail "launcher did not accept piped menu input"

--- a/tools/test_manifest_regression.sh
+++ b/tools/test_manifest_regression.sh
@@ -36,4 +36,24 @@ if worms_verify_manifest "$tmp_dir" "$manifest" 2>/dev/null; then
     fail "manifest verification did not detect file corruption"
 fi
 
+agl_root="$tmp_dir/agl-root"
+mkdir -p "$agl_root/Frameworks/AGL.framework/Versions/A/Resources"
+printf 'fake agl\n' > "$agl_root/Frameworks/AGL.framework/Versions/A/AGL"
+ln -s A "$agl_root/Frameworks/AGL.framework/Versions/Current"
+ln -s Versions/Current/AGL "$agl_root/Frameworks/AGL.framework/AGL"
+ln -s Versions/Current/Resources "$agl_root/Frameworks/AGL.framework/Resources"
+ln -s A "$agl_root/Frameworks/AGL.framework/Versions/A/A"
+ln -s Versions/Current/Resources "$agl_root/Frameworks/AGL.framework/Versions/A/Resources/Resources"
+
+if worms_validate_tree_symlinks "$agl_root" 2>/dev/null; then
+    fail "stale nested AGL framework symlinks unexpectedly passed validation before repair"
+fi
+worms_repair_agl_framework_symlinks "$agl_root"
+worms_validate_tree_symlinks "$agl_root" \
+    || fail "repaired AGL framework symlinks did not pass validation"
+[[ ! -L "$agl_root/Frameworks/AGL.framework/Versions/A/A" ]] \
+    || fail "AGL symlink repair left nested Versions/A/A"
+[[ ! -L "$agl_root/Frameworks/AGL.framework/Versions/A/Resources/Resources" ]] \
+    || fail "AGL symlink repair left nested Resources/Resources"
+
 printf 'Manifest regression check passed.\n'

--- a/tools/test_preflight_regression.sh
+++ b/tools/test_preflight_regression.sh
@@ -51,7 +51,7 @@ STUB
     cat > "$bin_dir/lipo" <<'STUB'
 #!/bin/bash
 if [[ "${1:-}" == "-archs" ]]; then
-    printf '%s\n' "x86_64"
+    printf '%s\n' "${WORMS_TEST_LIPO_ARCHS:-x86_64}"
     exit 0
 fi
 exit 1
@@ -74,6 +74,37 @@ run_preflight_for_version() {
         PATH="$fake_bin:$PATH" \
         GAME_APP="$game_app" \
         "$preflight" --quick 2>&1 || true
+}
+
+run_preflight_agl_case() {
+    local case_name="$1"
+    local agl_archs="$2"
+    local create_binary="$3"
+    local fake_bin="$tmp_dir/bin-agl-$case_name"
+    local game_app="$tmp_dir/game-agl-$case_name/Worms W.M.D.app"
+    local status
+
+    write_stub_tools "$fake_bin"
+    mkdir -p "$game_app/Contents/MacOS" "$game_app/Contents/Frameworks/AGL.framework/Versions/A"
+    : > "$game_app/Contents/MacOS/Worms W.M.D"
+    chmod +x "$game_app/Contents/MacOS/Worms W.M.D"
+    if [[ "$create_binary" == "true" ]]; then
+        : > "$game_app/Contents/Frameworks/AGL.framework/Versions/A/AGL"
+    fi
+
+    set +e
+    output=$(
+        WORMS_TEST_MACOS_VERSION=26.0.1 \
+            WORMS_TEST_ARCH=arm64 \
+            WORMS_TEST_LIPO_ARCHS="$agl_archs" \
+            PATH="$fake_bin:$PATH" \
+            GAME_APP="$game_app" \
+            "$preflight" --quick 2>&1
+    )
+    status=$?
+    set -e
+
+    printf '%s\t%s\n%s\n' "$status" "$case_name" "$output"
 }
 
 if grep -Fq 'https://ads.t17service.com' "$preflight"; then
@@ -129,5 +160,24 @@ grep -Fq 'macOS 27 (Golden Gate) detected' <<< "$preflight_27_output" \
 if grep -Fq 'macOS 26 (Tahoe) detected' <<< "$preflight_27_output"; then
     fail "preflight incorrectly reports macOS 26 for macOS 27"
 fi
+
+missing_agl_output=$(run_preflight_agl_case "missing-binary" "x86_64" "false")
+missing_agl_status=${missing_agl_output%%$'\t'*}
+if [[ "$missing_agl_status" -eq 0 ]]; then
+    fail "preflight succeeded with an AGL.framework directory but no AGL binary"
+fi
+grep -Fq "AGL stub binary NOT installed" <<< "$missing_agl_output" \
+    || fail "preflight did not report the missing AGL binary"
+if grep -Fq "AGL stub installed" <<< "$missing_agl_output"; then
+    fail "preflight reported AGL installed when the binary was missing"
+fi
+
+wrong_agl_output=$(run_preflight_agl_case "wrong-arch" "arm64" "true")
+wrong_agl_status=${wrong_agl_output%%$'\t'*}
+if [[ "$wrong_agl_status" -eq 0 ]]; then
+    fail "preflight succeeded with an AGL stub missing x86_64"
+fi
+grep -Fq "AGL stub does not include x86_64 architecture (arch: arm64)" <<< "$wrong_agl_output" \
+    || fail "preflight did not report the wrong AGL architecture"
 
 printf 'Preflight regression check passed.\n'

--- a/tools/test_support_bundle_sanitization.sh
+++ b/tools/test_support_bundle_sanitization.sh
@@ -34,6 +34,8 @@ grep -Fq 'oahd process' "$diagnostics_script" \
     || fail "diagnostics do not report oahd process status"
 grep -Fq 'game-test-tool status' "$diagnostics_script" \
     || fail "diagnostics do not report macOS 27 game-test-tool status"
+grep -Fq 'AGL stub missing x86_64 architecture' "$diagnostics_script" \
+    || fail "diagnostics do not fail AGL stubs that are missing x86_64"
 
 fake_game="/Users/privateperson/Library/Application Support/Steam/steamapps/common/WormsWMD/Worms W.M.D.app"
 external_game="/Volumes/Private Drive/privateperson@example.com/Worms W.M.D.app"

--- a/tools/test_support_bundle_sanitization.sh
+++ b/tools/test_support_bundle_sanitization.sh
@@ -15,7 +15,7 @@ fail() {
 assert_sanitized() {
     local path="$1"
 
-    if grep -Eq 'privateperson|privateperson@example\.com|/Users/privateperson|Token[[:space:]]*[:=][[:space:]]*abc123' "$path"; then
+    if grep -Eq 'privateperson|privateperson@example\.com|/Users/privateperson|abc123|lower-token-value|shhh-secret|p4ssw0rd|api-key-value' "$path"; then
         fail "sensitive synthetic value leaked in $path"
     fi
 }
@@ -39,10 +39,16 @@ grep -Fq 'AGL stub missing x86_64 architecture' "$diagnostics_script" \
 
 fake_game="/Users/privateperson/Library/Application Support/Steam/steamapps/common/WormsWMD/Worms W.M.D.app"
 external_game="/Volumes/Private Drive/privateperson@example.com/Worms W.M.D.app"
+sensitive_user="/Users/privateperson"
 plain_report="$tmp_dir/diagnostics.txt"
 external_report="$tmp_dir/external-diagnostics.txt"
 bundle_dir="$tmp_dir/bundles"
 extract_dir="$tmp_dir/extracted"
+test_home="$tmp_dir/home"
+fixture_repo="$tmp_dir/fixture-repo"
+fixture_home="$tmp_dir/fixture-home"
+fixture_bundle_dir="$tmp_dir/fixture-bundles"
+fixture_extract_dir="$tmp_dir/fixture-extracted"
 
 GAME_APP="$fake_game" "$diagnostics_script" > "$plain_report"
 assert_sanitized "$plain_report"
@@ -59,7 +65,34 @@ fi
 GAME_APP="$fake_game" "$diagnostics_script" --output "$tmp_dir/output.txt" >/dev/null
 assert_sanitized "$tmp_dir/output.txt"
 
-GAME_APP="$fake_game" "$diagnostics_script" --bundle --bundle-output "$bundle_dir" >/dev/null
+mkdir -p "$test_home/Library/Logs/WormsWMD-Fix"
+cat > "$test_home/Library/Logs/WormsWMD-Fix/fix_worms_wmd-20260101-000000.log" <<LOG
+ℹ  Log file: ${sensitive_user}/Library/Logs/WormsWMD-Fix/fix_worms_wmd-20260101-000000.log
+==> Creating backup...
+    Backup created: ${sensitive_user}/Documents/WormsWMD-Backup-20260101-000000
+==> Building AGL stub library...
+Token: abc123
+token=lower-token-value
+Secret: shhh-secret
+Password = p4ssw0rd
+API_KEY=api-key-value
+✗  ERROR: Required Qt framework missing from source: ${sensitive_user}/private-qt/QtSvg.framework
+LOG
+cat > "$test_home/Library/Logs/WormsWMD-Fix/fix_worms_wmd-20260101-000001.log" <<'LOG'
+==> Verifying installation...
+SUCCESS: All checks passed!
+ERROR: Post-verify failure
+Rolled back to original state.
+LOG
+
+mkdir -p "$test_home/Documents/WormsWMD-Backup-20260101-000000"
+cat > "$test_home/Documents/WormsWMD-Backup-20260101-000000/BACKUP_MANIFEST.tsv" <<'TSV'
+sha256	size	path
+hash	1	Frameworks/privateperson@example.com
+hash	1	Frameworks/API_KEY=api-key-value
+TSV
+
+HOME="$test_home" GAME_APP="$fake_game" "$diagnostics_script" --bundle --bundle-output "$bundle_dir" >/dev/null
 bundle_path=$(find "$bundle_dir" -mindepth 1 -maxdepth 1 -type f -name 'wormswmd-support-*.tar.gz' -print -quit)
 [[ -n "$bundle_path" ]] || fail "support bundle was not created"
 
@@ -67,12 +100,117 @@ mkdir -p "$extract_dir"
 tar -xzf "$bundle_path" -C "$extract_dir"
 assert_sanitized "$extract_dir/diagnostics.txt"
 
+for bundled_file in install-summary.txt runtime-invariants.txt backup-summary.txt qt-package.txt; do
+    [[ -f "$extract_dir/$bundled_file" ]] || fail "support bundle is missing $bundled_file"
+    assert_sanitized "$extract_dir/$bundled_file"
+done
+
+grep -Fq "Latest installer logs" "$extract_dir/install-summary.txt" \
+    || fail "install summary does not include latest installer logs"
+grep -Fq "Inferred outcome:" "$extract_dir/install-summary.txt" \
+    || fail "install summary does not include inferred outcome"
+grep -Fq "Inferred outcome: failure: rollback completed" "$extract_dir/install-summary.txt" \
+    || fail "install summary misclassified a mixed success/error rollback log"
+grep -Fq "Required runtime invariant matrix" "$extract_dir/runtime-invariants.txt" \
+    || fail "runtime invariant matrix is missing"
+grep -Fq "Backup integrity summary" "$extract_dir/backup-summary.txt" \
+    || fail "backup summary is missing"
+if ! grep -Fq "Local package: none" "$extract_dir/qt-package.txt"; then
+    grep -Fq "Required archive contents" "$extract_dir/qt-package.txt" \
+        || fail "Qt package summary does not verify required archive contents"
+    grep -Eq "(PASS framework binary:|FAIL framework binary missing:) Frameworks/QtDBus[.]framework/Versions/5/QtDBus" "$extract_dir/qt-package.txt" \
+        || fail "Qt package summary does not report required QtDBus binary status"
+    grep -Eq "(PASS plugin:|FAIL plugin missing:) PlugIns/platforms/libqcocoa[.]dylib" "$extract_dir/qt-package.txt" \
+        || fail "Qt package summary does not report required platform plugin status"
+fi
+[[ -f "$extract_dir/backup-manifests/backup-manifest-01.tsv" ]] \
+    || fail "support bundle did not include a sanitized backup manifest"
+assert_sanitized "$extract_dir/backup-manifests/backup-manifest-01.tsv"
+
 if ! tar -tvzf "$bundle_path" | awk '{ if ($3 != "root" || $4 != "wheel") exit 1 }'; then
     fail "support bundle archive leaks local owner or group metadata"
 fi
 
-if find "$extract_dir" -type f -print0 | xargs -0 grep -Eq 'privateperson|privateperson@example\.com|/Users/privateperson'; then
+if find "$extract_dir" -type f -print0 | xargs -0 grep -Eq 'privateperson|privateperson@example\.com|/Users/privateperson|abc123|lower-token-value|shhh-secret|p4ssw0rd|api-key-value'; then
     fail "support bundle contains a sensitive synthetic value"
 fi
+
+mkdir -p "$fixture_repo/tools" "$fixture_repo/scripts" "$fixture_repo/dist" "$fixture_repo/pkg" "$fixture_home"
+cp "$diagnostics_script" "$fixture_repo/tools/collect_diagnostics.sh"
+cp "$ROOT_DIR/scripts/common.sh" "$fixture_repo/scripts/common.sh"
+cp "$ROOT_DIR/scripts/ui.sh" "$fixture_repo/scripts/ui.sh"
+cat > "$fixture_repo/fix_worms_wmd.sh" <<'SH'
+VERSION="test"
+SH
+cat > "$fixture_repo/scripts/download_qt_frameworks.sh" <<'SH'
+#!/bin/bash
+if [[ "${1:-}" == "--check" ]]; then
+    echo "available"
+else
+    echo "available"
+fi
+SH
+chmod +x "$fixture_repo/scripts/download_qt_frameworks.sh" "$fixture_repo/tools/collect_diagnostics.sh"
+
+cat > "$fixture_repo/pkg/METADATA.txt" <<'META'
+Qt Version: 5.15.42
+Architecture: x86_64
+Source: Qt prefix (/Users/privateperson/private-qt)
+Token: abc123
+API_KEY=api-key-value
+META
+(
+    cd "$fixture_repo/pkg"
+    tar -czf "$fixture_repo/dist/qt-frameworks-x86_64-5.15.42.tar.gz" METADATA.txt
+)
+(
+    cd "$fixture_repo/dist"
+    shasum -a 256 qt-frameworks-x86_64-5.15.42.tar.gz > qt-frameworks-x86_64-5.15.42.tar.gz.sha256
+)
+
+HOME="$fixture_home" GAME_APP="$fake_game" "$fixture_repo/tools/collect_diagnostics.sh" --bundle --bundle-output "$fixture_bundle_dir" >/dev/null
+fixture_bundle_path=$(find "$fixture_bundle_dir" -mindepth 1 -maxdepth 1 -type f -name 'wormswmd-support-*.tar.gz' -print -quit)
+[[ -n "$fixture_bundle_path" ]] || fail "fixture support bundle was not created"
+
+mkdir -p "$fixture_extract_dir"
+tar -xzf "$fixture_bundle_path" -C "$fixture_extract_dir"
+assert_sanitized "$fixture_extract_dir/qt-package.txt"
+grep -Fq "Source: Qt prefix (" "$fixture_extract_dir/qt-package.txt" \
+    || fail "fixture Qt package metadata was not included"
+grep -Fq "[redacted-secret]" "$fixture_extract_dir/qt-package.txt" \
+    || fail "fixture Qt package metadata did not redact secret-like values"
+
+rm -rf "$fixture_bundle_dir" "$fixture_extract_dir"
+rm -f "$fixture_repo/dist/qt-frameworks-x86_64-5.15.42.tar.gz" "$fixture_repo/dist/qt-frameworks-x86_64-5.15.42.tar.gz.sha256"
+(
+    cd "$fixture_repo/pkg"
+    tar -czf "$fixture_repo/dist/qt-frameworks-x86_64-5.15.43.tar.gz" METADATA.txt
+)
+HOME="$fixture_home" GAME_APP="$fake_game" "$fixture_repo/tools/collect_diagnostics.sh" --bundle --bundle-output "$fixture_bundle_dir" >/dev/null
+fixture_bundle_path=$(find "$fixture_bundle_dir" -mindepth 1 -maxdepth 1 -type f -name 'wormswmd-support-*.tar.gz' -print -quit)
+[[ -n "$fixture_bundle_path" ]] || fail "fixture missing-checksum support bundle was not created"
+mkdir -p "$fixture_extract_dir"
+tar -xzf "$fixture_bundle_path" -C "$fixture_extract_dir"
+grep -Fq "Local package: qt-frameworks-x86_64-5.15.43.tar.gz" "$fixture_extract_dir/qt-package.txt" \
+    || fail "Qt package summary hid a local package with missing checksum"
+grep -Fq "Checksum: missing" "$fixture_extract_dir/qt-package.txt" \
+    || fail "Qt package summary did not report a missing checksum"
+
+rm -rf "$fixture_bundle_dir" "$fixture_extract_dir"
+rm -f "$fixture_repo/dist/qt-frameworks-x86_64-5.15.43.tar.gz"
+printf 'not a gzip archive\n' > "$fixture_repo/dist/qt-frameworks-x86_64-5.15.44.tar.gz"
+(
+    cd "$fixture_repo/dist"
+    shasum -a 256 qt-frameworks-x86_64-5.15.44.tar.gz > qt-frameworks-x86_64-5.15.44.tar.gz.sha256
+)
+HOME="$fixture_home" GAME_APP="$fake_game" "$fixture_repo/tools/collect_diagnostics.sh" --bundle --bundle-output "$fixture_bundle_dir" >/dev/null
+fixture_bundle_path=$(find "$fixture_bundle_dir" -mindepth 1 -maxdepth 1 -type f -name 'wormswmd-support-*.tar.gz' -print -quit)
+[[ -n "$fixture_bundle_path" ]] || fail "fixture corrupt-archive support bundle was not created"
+mkdir -p "$fixture_extract_dir"
+tar -xzf "$fixture_bundle_path" -C "$fixture_extract_dir"
+grep -Fq "Local package: qt-frameworks-x86_64-5.15.44.tar.gz" "$fixture_extract_dir/qt-package.txt" \
+    || fail "Qt package summary hid a corrupt local package"
+grep -Fq "FAIL unable to list archive contents" "$fixture_extract_dir/qt-package.txt" \
+    || fail "Qt package summary did not report corrupt archive contents"
 
 printf 'Support bundle sanitization check passed.\n'

--- a/tools/watch_for_updates.sh
+++ b/tools/watch_for_updates.sh
@@ -76,10 +76,13 @@ EOF
 # Check if the fix is still applied
 check_fix_status() {
     local game_frameworks="$GAME_APP/Contents/Frameworks"
+    local game_plugins="$GAME_APP/Contents/PlugIns"
 
     # Quick checks for fix status
     local has_agl=false
     local has_qt515=false
+    local has_required_runtime=true
+    local required_fw
 
     # Check AGL stub (small file = stub)
     if [[ -f "$game_frameworks/AGL.framework/Versions/A/AGL" ]]; then
@@ -98,7 +101,18 @@ check_fix_status() {
         fi
     fi
 
-    if $has_agl && $has_qt515; then
+    for required_fw in QtCore QtGui QtWidgets QtOpenGL QtPrintSupport QtDBus QtSvg; do
+        if [[ ! -d "$game_frameworks/$required_fw.framework" ]]; then
+            has_required_runtime=false
+            break
+        fi
+    done
+    if [[ ! -f "$game_plugins/platforms/libqcocoa.dylib" ]] \
+        || [[ ! -f "$game_plugins/imageformats/libqsvg.dylib" ]]; then
+        has_required_runtime=false
+    fi
+
+    if $has_agl && $has_qt515 && $has_required_runtime; then
         echo "applied"
     elif $has_agl || $has_qt515; then
         echo "partial"
@@ -182,7 +196,7 @@ do_daemon() {
                         if prompt_reapply; then
                             echo "Reapplying fix..."
                             cd "$REPO_DIR"
-                            ./fix_worms_wmd.sh --force
+                            GAME_APP="$GAME_APP" ./fix_worms_wmd.sh --force
                             send_notification "Worms W.M.D Fix" "Fix successfully reapplied!"
                         fi
                         ;;
@@ -204,11 +218,12 @@ do_daemon() {
 do_install() {
     echo "Installing update watcher as LaunchAgent..."
     local launch_domain="gui/${UID}"
-    local watcher_path log_path
+    local watcher_path log_path game_app_path
 
     mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/WormsWMD-Fix"
     watcher_path=$(printf '%s' "${SCRIPT_DIR}/watch_for_updates.sh" | xml_escape)
     log_path=$(printf '%s' "${HOME}/Library/Logs/WormsWMD-Fix/watcher.log" | xml_escape)
+    game_app_path=$(printf '%s' "$GAME_APP" | xml_escape)
 
     # Create LaunchAgent plist
     cat > "$LAUNCH_AGENT_PATH" << EOF
@@ -223,6 +238,11 @@ do_install() {
         <string>${watcher_path}</string>
         <string>--daemon</string>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GAME_APP</key>
+        <string>${game_app_path}</string>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -301,7 +321,7 @@ case "${1:-}" in
                 echo ""
                 if [[ ! "${REPLY:-}" =~ ^[Nn]$ ]]; then
                     cd "$REPO_DIR"
-                    ./fix_worms_wmd.sh
+                    GAME_APP="$GAME_APP" ./fix_worms_wmd.sh
                 fi
                 ;;
         esac


### PR DESCRIPTION
## Summary

Fixes #12.

This hardens the installer against partial runtime installs and misleading success states. The fixer is responsible for supplying the AGL/Qt runtime assets; if a release artifact, cache, build output, or selected Qt source cannot supply them, that is an installer invariant violation, not a user-provided dependency. The root cause was broader than the reported missing AGL stub: runtime asset invariants, helper failures, rollback behavior, repeated-install framework symlink layout, and support-bundle observability all needed stricter validation or self-heal behavior.

## Changes

- Require complete fixer-supplied AGL, Qt framework, Qt plugin, and bundled dependency state before verification can pass.
- Fail early when the release artifact, cache, build output, or selected Qt source is incomplete.
- Fix Bash 3.2 rollback trap inheritance so post-backup failures roll back.
- Build AGL x86_64 slices with native `clang -arch x86_64`, not Rosetta-launched `clang`.
- Repair stale AGL framework symlinks in backup copies and avoid recreating nested framework symlinks on repeated installs.
- Preserve custom `GAME_APP` in watcher reapply and LaunchAgent paths.
- Restore save backups exactly rather than merging stale files over restored roots.
- Expand support bundles with sanitized installer history, runtime invariant status, backup integrity status, and required Qt archive content checks.
- Sanitize Qt package metadata and copied backup manifests; avoid backup-derived manifest filenames in support archives.
- Make default installer logs process-specific so same-second runs do not mix into one log file.
- Add focused regression coverage and update docs, runbooks, CI, and audit plans.

## Validation

Current local validation passed on 2026-06-29 for commit `32e7cf4`:

```bash
./tools/validate_harness.sh
./tools/test_dependency_parsing.sh
./tools/test_issue_10_regression.sh
./tools/test_issue_11_game_detection.sh
./tools/test_issue_12_agl_install_failure.sh
./tools/test_installer_rollback_regression.sh
./tools/test_support_bundle_sanitization.sh
./tools/test_backup_saves_regression.sh
./tools/test_launcher_friction.sh
./tools/test_preflight_regression.sh
./tools/test_manifest_regression.sh
./tools/test_qt_version_pinning.sh
./scripts/download_qt_frameworks.sh --check
for script in fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh; do bash -n "$script"; done
shellcheck fix_worms_wmd.sh install.sh "Install Fix.command" "Worms W.M.D Fix.command" scripts/*.sh tools/*.sh
./tools/build_release_bundle.sh --version local-support --skip-zip
clang -Wall -Wextra -Werror -arch x86_64 -dynamiclib -o /tmp/AGL_test -framework OpenGL src/agl_stub.c
git diff --check
```

Real non-mutating validation also passed on this macOS 27 Apple Silicon machine using the local Steam install:

```bash
./fix_worms_wmd.sh --verify
./tools/preflight_check.sh
./fix_worms_wmd.sh --dry-run
./tools/collect_diagnostics.sh --bundle --bundle-output "$tmp_dir"
```

Additional targeted validation passed:

- Extracted a real support bundle and verified `diagnostics.txt`, `install-summary.txt`, `runtime-invariants.txt`, `backup-summary.txt`, `qt-package.txt`, and numbered sanitized backup manifests are present.
- Ran a parallel `--verify` and `--dry-run` smoke and confirmed same-second invocations wrote separate log files.
- The support-bundle regression covers mixed success/error rollback logs, Qt metadata redaction, backup-manifest redaction, missing Qt checksums, and corrupt Qt archives.
- CI passed on commit `32e7cf4`: Validate Scripts, ShellCheck, and Validate C Code.
- Release Bundle workflow run `28407168209` passed on commit `32e7cf4`; the uploaded zip downloaded locally, passed `shasum -a 256 -c`, and extracted with the expected release layout.

Earlier installed-game apply and packaged artifact validation on this branch also passed after the runtime hardening changes: forced install, verify, preflight, diagnostics, launcher option 3, LaunchAgent install/check/uninstall, checksum-verified local release zip extraction, packaged forced install, and bounded launch with no recent crash report.

## Remaining limits

- No real macOS 26.0.1 M1 Air was available locally.
- No real GOG Worms W.M.D install was available locally.
- Intel Homebrew under `/usr/local/bin/brew` was not installed on this host, so the Homebrew Qt fallback was not live-installed.

